### PR TITLE
Remove RawWindowHandleEx

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,10 @@
 [package]
 name = "raw-window-handle"
 version = "0.1.0"
-authors = ["Osspial <osspial@gmail.com>"]
+authors = [
+	"Osspial <osspial@gmail.com>",
+	"Dzmitry Malyshau <kvarkus@gmail.com>",
+]
 edition = "2018"
 description = "Raw platform window types for interoperability"
 license = "Unlicense"

--- a/src/ios.rs
+++ b/src/ios.rs
@@ -1,19 +1,14 @@
 use core::ptr;
 use libc::c_void;
 
-pub trait RawWindowHandleEx {
-    fn new(handle: IOSHandle) -> Self;
-    fn ios_handle(&self) -> IOSHandle;
-}
-
-impl RawWindowHandleEx for crate::RawWindowHandle {
-    fn new(handle: IOSHandle) -> Self {
+impl crate::RawWindowHandle {
+    pub fn new(handle: IOSHandle) -> Self {
         Self {
             handle: RawWindowHandle { handle },
         }
     }
 
-    fn ios_handle(&self) -> IOSHandle {
+    pub fn ios_handle(&self) -> IOSHandle {
         self.handle.handle
     }
 }
@@ -31,8 +26,8 @@ pub struct IOSHandle {
 }
 
 impl IOSHandle {
-    pub fn empty() -> IOSHandle {
-        IOSHandle {
+    pub fn empty() -> Self {
+        Self {
             ui_window: ptr::null_mut(),
             ui_view: ptr::null_mut(),
             ui_view_controller: ptr::null_mut(),

--- a/src/macos.rs
+++ b/src/macos.rs
@@ -1,19 +1,14 @@
 use core::ptr;
 use libc::c_void;
 
-pub trait RawWindowHandleEx {
-    fn new(handle: MacOSHandle) -> Self;
-    fn macos_handle(&self) -> MacOSHandle;
-}
-
-impl RawWindowHandleEx for crate::RawWindowHandle {
-    fn new(handle: MacOSHandle) -> Self {
+impl crate::RawWindowHandle {
+    pub fn new(handle: MacOSHandle) -> Self {
         Self {
             handle: RawWindowHandle { handle },
         }
     }
 
-    fn macos_handle(&self) -> MacOSHandle {
+    pub fn macos_handle(&self) -> MacOSHandle {
         self.handle.handle
     }
 }
@@ -31,8 +26,8 @@ pub struct MacOSHandle {
 }
 
 impl MacOSHandle {
-    pub fn empty() -> MacOSHandle {
-        MacOSHandle {
+    pub fn empty() -> Self {
+        Self {
             ns_window: ptr::null_mut(),
             ns_view: ptr::null_mut(),
             _non_exhaustive: (),

--- a/src/unix.rs
+++ b/src/unix.rs
@@ -1,15 +1,8 @@
 use core::ptr;
 use libc::{c_ulong, c_void};
 
-pub trait RawWindowHandleEx {
-    fn new_x11(handle: X11Handle) -> Self;
-    fn new_wayland(handle: WaylandHandle) -> Self;
-    fn x11_handle(&self) -> Option<X11Handle>;
-    fn wayland_handle(&self) -> Option<WaylandHandle>;
-}
-
-impl RawWindowHandleEx for crate::RawWindowHandle {
-    fn new_x11(handle: X11Handle) -> Self {
+impl crate::RawWindowHandle {
+    pub fn new_x11(handle: X11Handle) -> Self {
         Self {
             handle: RawWindowHandle {
                 handle: UnixHandle::X11(handle),
@@ -17,7 +10,7 @@ impl RawWindowHandleEx for crate::RawWindowHandle {
         }
     }
 
-    fn new_wayland(handle: WaylandHandle) -> Self {
+    pub fn new_wayland(handle: WaylandHandle) -> Self {
         Self {
             handle: RawWindowHandle {
                 handle: UnixHandle::Wayland(handle),
@@ -25,14 +18,14 @@ impl RawWindowHandleEx for crate::RawWindowHandle {
         }
     }
 
-    fn x11_handle(&self) -> Option<X11Handle> {
+    pub fn x11_handle(&self) -> Option<X11Handle> {
         match self.handle.handle {
             UnixHandle::X11(handle) => Some(handle),
             UnixHandle::Wayland(_) => None,
         }
     }
 
-    fn wayland_handle(&self) -> Option<WaylandHandle> {
+    pub fn wayland_handle(&self) -> Option<WaylandHandle> {
         match self.handle.handle {
             UnixHandle::X11(_) => None,
             UnixHandle::Wayland(handle) => Some(handle),
@@ -64,8 +57,8 @@ pub struct WaylandHandle {
 }
 
 impl X11Handle {
-    pub fn empty() -> X11Handle {
-        X11Handle {
+    pub fn empty() -> Self {
+        Self {
             window: 0,
             display: ptr::null_mut(),
             _non_exhaustive: (),
@@ -74,8 +67,8 @@ impl X11Handle {
 }
 
 impl WaylandHandle {
-    pub fn empty() -> WaylandHandle {
-        WaylandHandle {
+    pub fn empty() -> Self {
+        Self {
             surface: ptr::null_mut(),
             display: ptr::null_mut(),
             _non_exhaustive: (),

--- a/src/windows.rs
+++ b/src/windows.rs
@@ -1,19 +1,14 @@
 use core::ptr;
 use libc::c_void;
 
-pub trait RawWindowHandleEx {
-    fn new(handle: WindowsHandle) -> Self;
-    fn windows_handle(&self) -> WindowsHandle;
-}
-
-impl RawWindowHandleEx for crate::RawWindowHandle {
-    fn new(handle: WindowsHandle) -> Self {
+impl crate::RawWindowHandle {
+    pub fn new(handle: WindowsHandle) -> Self {
         Self {
             handle: RawWindowHandle { handle },
         }
     }
 
-    fn windows_handle(&self) -> WindowsHandle {
+    pub fn windows_handle(&self) -> WindowsHandle {
         self.handle.handle
     }
 }
@@ -30,8 +25,8 @@ pub struct WindowsHandle {
 }
 
 impl WindowsHandle {
-    pub fn empty() -> WindowsHandle {
-        WindowsHandle {
+    pub fn empty() -> Self {
+        Self {
             hwnd: ptr::null_mut(),
             _non_exhaustive: (),
         }


### PR DESCRIPTION
I see the value in traits that abstract away multiple implementations. In this case, there is a custom trait per platform. Is the original idea that winit/SDL/GLFW would implement those traits? If so, is there a downside for them to just return `RawWindowHandle` to begin with?