### PR TITLE
Add documentation

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,3 +1,4 @@
+//! Interoperability library for Rust Windowing applications.
 #![cfg_attr(feature = "nightly-docs", feature(doc_cfg))]
 #![no_std]
 
@@ -54,7 +55,13 @@ mod platform {
     pub use crate::ios::*;
 }
 
-pub trait HasRawWindowHandle {
+//! Window that wraps around a raw window handle.
+//!
+//! It is entirely valid behavior for fields within each platform-specific `RawWindowHandle` variant
+//! to be `null` or `0`, and appropriate checking should be done before the handle is used. However,
+//! users can safely assume that non-`null`/`0` fields are valid handles, and it is up to the
+//! implementor of this trait to ensure that condition is upheld.
+pub unsafe trait HasRawWindowHandle {
     fn raw_window_handle(&self) -> RawWindowHandle;
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -55,12 +55,12 @@ mod platform {
     pub use crate::ios::*;
 }
 
-//! Window that wraps around a raw window handle.
-//!
-//! It is entirely valid behavior for fields within each platform-specific `RawWindowHandle` variant
-//! to be `null` or `0`, and appropriate checking should be done before the handle is used. However,
-//! users can safely assume that non-`null`/`0` fields are valid handles, and it is up to the
-//! implementor of this trait to ensure that condition is upheld.
+/// Window that wraps around a raw window handle.
+///
+/// It is entirely valid behavior for fields within each platform-specific `RawWindowHandle` variant
+/// to be `null` or `0`, and appropriate checking should be done before the handle is used. However,
+/// users can safely assume that non-`null`/`0` fields are valid handles, and it is up to the
+/// implementor of this trait to ensure that condition is upheld.
 pub unsafe trait HasRawWindowHandle {
     fn raw_window_handle(&self) -> RawWindowHandle;
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -61,6 +61,9 @@ mod platform {
 /// to be `null` or `0`, and appropriate checking should be done before the handle is used. However,
 /// users can safely assume that non-`null`/`0` fields are valid handles, and it is up to the
 /// implementor of this trait to ensure that condition is upheld.
+///
+/// The exact handle returned by `raw_window_handle` must not change during the lifetime of this
+/// trait's implementor.
 pub unsafe trait HasRawWindowHandle {
     fn raw_window_handle(&self) -> RawWindowHandle;
 }


### PR DESCRIPTION
Add basic documentation. Also makes `HasRawWindowHandle` an `unsafe` trait, since the correctness of downstream applications relies on it being implemented properly.