### PR TITLE
Fix non-exhaustive implementation preventing platform structs from being created``

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,11 @@
+# 0.1.2 (2019-08-13)
+
+* Fix use of private `_non_exhaustive` field in platform handle structs preventing structs from getting initialized.
+
+# 0.1.1 (2019-08-13)
+
+* Flesh out Cargo.toml, adding crates.io info rendering tags.
+
+# 0.1.0 (2019-08-13)
+
+* Initial release.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "raw-window-handle"
-version = "0.1.1"
+version = "0.1.2"
 authors = ["Osspial <osspial@gmail.com>"]
 edition = "2018"
 description = "Raw platform window types for interoperability"

--- a/src/ios.rs
+++ b/src/ios.rs
@@ -1,6 +1,16 @@
 use core::ptr;
 use libc::c_void;
 
+/// Raw window handle for iOS.
+///
+/// ## Construction
+/// ```
+/// # use raw_window_handle::ios::IOSHandle;
+/// let handle = IOSHandle {
+///     /* fields */
+///     ..IOSHandle::empty()
+/// };
+/// ```
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct IOSHandle {
     pub ui_window: *mut c_void,
@@ -13,6 +23,7 @@ pub struct IOSHandle {
 
 impl IOSHandle {
     pub fn empty() -> IOSHandle {
+        #[allow(deprecated)]
         IOSHandle {
             ui_window: ptr::null_mut(),
             ui_view: ptr::null_mut(),

--- a/src/ios.rs
+++ b/src/ios.rs
@@ -6,7 +6,9 @@ pub struct IOSHandle {
     pub ui_window: *mut c_void,
     pub ui_view: *mut c_void,
     pub ui_view_controller: *mut c_void,
-    _non_exhaustive: (),
+    #[doc(hidden)]
+    #[deprecated = "This field is used to ensure that this struct is non-exhaustive, so that it may be extended in the future. Do not refer to this field."]
+    pub _non_exhaustive_do_not_use: crate::seal::Seal,
 }
 
 impl IOSHandle {
@@ -15,7 +17,7 @@ impl IOSHandle {
             ui_window: ptr::null_mut(),
             ui_view: ptr::null_mut(),
             ui_view_controller: ptr::null_mut(),
-            _non_exhaustive: (),
+            _non_exhaustive_do_not_use: crate::seal::Seal,
         }
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,7 +2,11 @@
 //!
 //! ## Platform handle initialization
 //!
-//! Each platform handle struct is purposefully non-exhaustive,
+//! Each platform handle struct is purposefully non-exhaustive, so that additional fields may be
+//! added without breaking backwards compatibility. Each struct provides an `empty` method that may
+//! be used along with the struct update syntax to construct it. See each specific struct for
+//! examples.
+//!
 #![cfg_attr(feature = "nightly-docs", feature(doc_cfg))]
 #![no_std]
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,8 @@
 //! Interoperability library for Rust Windowing applications.
+//!
+//! ## Platform handle initialization
+//!
+//! Each platform handle struct is purposefully non-exhaustive,
 #![cfg_attr(feature = "nightly-docs", feature(doc_cfg))]
 #![no_std]
 
@@ -126,9 +130,11 @@ pub enum RawWindowHandle {
     Windows(windows::WindowsHandle),
 
     #[doc(hidden)]
+    #[deprecated = "This field is used to ensure that this struct is non-exhaustive, so that it may be extended in the future. Do not refer to this field."]
     __NonExhaustiveDoNotUse(seal::Seal),
 }
 
 mod seal {
-    pub enum Seal {}
+    #[derive(Debug, Clone, Copy, PartialEq, Eq)]
+    pub struct Seal;
 }

--- a/src/macos.rs
+++ b/src/macos.rs
@@ -1,6 +1,16 @@
 use core::ptr;
 use libc::c_void;
 
+/// Raw window handle for macOS.
+///
+/// ## Construction
+/// ```
+/// # use raw_window_handle::macos::MacOSHandle;
+/// let handle = MacOSHandle {
+///     /* fields */
+///     ..MacOSHandle::empty()
+/// };
+/// ```
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct MacOSHandle {
     pub ns_window: *mut c_void,
@@ -13,6 +23,7 @@ pub struct MacOSHandle {
 
 impl MacOSHandle {
     pub fn empty() -> MacOSHandle {
+        #[allow(deprecated)]
         MacOSHandle {
             ns_window: ptr::null_mut(),
             ns_view: ptr::null_mut(),

--- a/src/macos.rs
+++ b/src/macos.rs
@@ -6,7 +6,9 @@ pub struct MacOSHandle {
     pub ns_window: *mut c_void,
     pub ns_view: *mut c_void,
     // TODO: WHAT ABOUT ns_window_controller and ns_view_controller?
-    _non_exhaustive: (),
+    #[doc(hidden)]
+    #[deprecated = "This field is used to ensure that this struct is non-exhaustive, so that it may be extended in the future. Do not refer to this field."]
+    pub _non_exhaustive_do_not_use: crate::seal::Seal,
 }
 
 impl MacOSHandle {
@@ -14,7 +16,7 @@ impl MacOSHandle {
         MacOSHandle {
             ns_window: ptr::null_mut(),
             ns_view: ptr::null_mut(),
-            _non_exhaustive: (),
+            _non_exhaustive_do_not_use: crate::seal::Seal,
         }
     }
 }

--- a/src/unix.rs
+++ b/src/unix.rs
@@ -1,6 +1,16 @@
 use core::ptr;
 use libc::{c_ulong, c_void};
 
+/// Raw window handle for X11.
+///
+/// ## Construction
+/// ```
+/// # use raw_window_handle::unix::X11Handle;
+/// let handle = X11Handle {
+///     /* fields */
+///     ..X11Handle::empty()
+/// };
+/// ```
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct X11Handle {
     pub window: c_ulong,
@@ -10,6 +20,16 @@ pub struct X11Handle {
     pub _non_exhaustive_do_not_use: crate::seal::Seal,
 }
 
+/// Raw window handle for Wayland.
+///
+/// ## Construction
+/// ```
+/// # use raw_window_handle::unix::WaylandHandle;
+/// let handle = WaylandHandle {
+///     /* fields */
+///     ..WaylandHandle::empty()
+/// };
+/// ```
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct WaylandHandle {
     pub surface: *mut c_void,
@@ -21,6 +41,7 @@ pub struct WaylandHandle {
 
 impl X11Handle {
     pub fn empty() -> X11Handle {
+        #[allow(deprecated)]
         X11Handle {
             window: 0,
             display: ptr::null_mut(),
@@ -31,6 +52,7 @@ impl X11Handle {
 
 impl WaylandHandle {
     pub fn empty() -> WaylandHandle {
+        #[allow(deprecated)]
         WaylandHandle {
             surface: ptr::null_mut(),
             display: ptr::null_mut(),

--- a/src/unix.rs
+++ b/src/unix.rs
@@ -5,14 +5,18 @@ use libc::{c_ulong, c_void};
 pub struct X11Handle {
     pub window: c_ulong,
     pub display: *mut c_void,
-    _non_exhaustive: (),
+    #[doc(hidden)]
+    #[deprecated = "This field is used to ensure that this struct is non-exhaustive, so that it may be extended in the future. Do not refer to this field."]
+    pub _non_exhaustive_do_not_use: crate::seal::Seal,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct WaylandHandle {
     pub surface: *mut c_void,
     pub display: *mut c_void,
-    _non_exhaustive: (),
+    #[doc(hidden)]
+    #[deprecated = "This field is used to ensure that this struct is non-exhaustive, so that it may be extended in the future. Do not refer to this field."]
+    pub _non_exhaustive_do_not_use: crate::seal::Seal,
 }
 
 impl X11Handle {
@@ -20,7 +24,7 @@ impl X11Handle {
         X11Handle {
             window: 0,
             display: ptr::null_mut(),
-            _non_exhaustive: (),
+            _non_exhaustive_do_not_use: crate::seal::Seal,
         }
     }
 }
@@ -30,7 +34,7 @@ impl WaylandHandle {
         WaylandHandle {
             surface: ptr::null_mut(),
             display: ptr::null_mut(),
-            _non_exhaustive: (),
+            _non_exhaustive_do_not_use: crate::seal::Seal,
         }
     }
 }

--- a/src/windows.rs
+++ b/src/windows.rs
@@ -1,6 +1,17 @@
 use core::ptr;
 use libc::c_void;
 
+
+/// Raw window handle for Windows.
+///
+/// ## Construction
+/// ```
+/// # use raw_window_handle::windows::WindowsHandle;
+/// let handle = WindowsHandle {
+///     /* fields */
+///     ..WindowsHandle::empty()
+/// };
+/// ```
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct WindowsHandle {
     pub hwnd: *mut c_void,
@@ -11,6 +22,7 @@ pub struct WindowsHandle {
 
 impl WindowsHandle {
     pub fn empty() -> WindowsHandle {
+        #[allow(deprecated)]
         WindowsHandle {
             hwnd: ptr::null_mut(),
             _non_exhaustive_do_not_use: crate::seal::Seal,

--- a/src/windows.rs
+++ b/src/windows.rs
@@ -4,14 +4,16 @@ use libc::c_void;
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct WindowsHandle {
     pub hwnd: *mut c_void,
-    _non_exhaustive: (),
+    #[doc(hidden)]
+    #[deprecated = "This field is used to ensure that this struct is non-exhaustive, so that it may be extended in the future. Do not refer to this field."]
+    pub _non_exhaustive_do_not_use: crate::seal::Seal,
 }
 
 impl WindowsHandle {
     pub fn empty() -> WindowsHandle {
         WindowsHandle {
             hwnd: ptr::null_mut(),
-            _non_exhaustive: (),
+            _non_exhaustive_do_not_use: crate::seal::Seal,
         }
     }
 }

--- a/src/windows.rs
+++ b/src/windows.rs
@@ -1,7 +1,6 @@
 use core::ptr;
 use libc::c_void;
 
-
 /// Raw window handle for Windows.
 ///
 /// ## Construction


### PR DESCRIPTION
...which makes this crate usable. Also releases `0.1.2` to crates.io.