### PR TITLE
Fixes for issue #3, #11 and #12

### DIFF
--- a/src/android.rs
+++ b/src/android.rs
@@ -1,29 +1,29 @@
 use core::ffi::c_void;
 use core::ptr;
 
-/// Raw window handle for Windows.
+/// Raw window handle for Android.
 ///
 /// ## Construction
 /// ```
-/// # use raw_window_handle::windows::WindowsHandle;
-/// let handle = WindowsHandle {
+/// # use raw_window_handle::android::AndroidHandle;
+/// let handle = AndroidHandle {
 ///     /* fields */
-///     ..WindowsHandle::empty()
+///     ..AndroidHandle::empty()
 /// };
 /// ```
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub struct WindowsHandle {
-    pub hwnd: *mut c_void,
+pub struct AndroidHandle {
+    pub a_native_window: *mut c_void,
     #[doc(hidden)]
     #[deprecated = "This field is used to ensure that this struct is non-exhaustive, so that it may be extended in the future. Do not refer to this field."]
     pub _non_exhaustive_do_not_use: crate::seal::Seal,
 }
 
-impl WindowsHandle {
+impl AndroidHandle {
     pub fn empty() -> Self {
         #[allow(deprecated)]
         Self {
-            hwnd: ptr::null_mut(),
+            a_native_window: ptr::null_mut(),
             _non_exhaustive_do_not_use: crate::seal::Seal,
         }
     }

--- a/src/ios.rs
+++ b/src/ios.rs
@@ -22,9 +22,9 @@ pub struct IOSHandle {
 }
 
 impl IOSHandle {
-    pub fn empty() -> IOSHandle {
+    pub fn empty() -> Self {
         #[allow(deprecated)]
-        IOSHandle {
+        Self {
             ui_window: ptr::null_mut(),
             ui_view: ptr::null_mut(),
             ui_view_controller: ptr::null_mut(),

--- a/src/ios.rs
+++ b/src/ios.rs
@@ -1,5 +1,5 @@
 use core::ptr;
-use libc::c_void;
+use core::ffi::c_void;
 
 /// Raw window handle for iOS.
 ///

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -105,7 +105,29 @@ pub enum RawWindowHandle {
             target_os = "openbsd"
         ))
     )]
-    X11(unix::X11Handle),
+    Xlib(unix::XlibHandle),
+
+    #[cfg_attr(
+        feature = "nightly-docs",
+            doc(cfg(any(
+            target_os = "linux",
+            target_os = "dragonfly",
+            target_os = "freebsd",
+            target_os = "netbsd",
+            target_os = "openbsd"
+        )))
+    )]
+    #[cfg_attr(
+        not(feature = "nightly-docs"),
+            cfg(any(
+            target_os = "linux",
+            target_os = "dragonfly",
+            target_os = "freebsd",
+            target_os = "netbsd",
+            target_os = "openbsd"
+        ))
+    )]
+    Xcb(unix::XcbHandle),
 
     #[cfg_attr(
         feature = "nightly-docs",

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -37,7 +37,9 @@ pub mod unix;
 #[cfg_attr(feature = "nightly-docs", doc(cfg(target_os = "windows")))]
 #[cfg_attr(not(feature = "nightly-docs"), cfg(target_os = "windows"))]
 pub mod windows;
-// pub mod android;
+#[cfg_attr(feature = "nightly-docs", doc(cfg(target_os = "android")))]
+#[cfg_attr(not(feature = "nightly-docs"), cfg(target_os = "android"))]
+pub mod android;
 #[cfg_attr(feature = "nightly-docs", doc(cfg(target_os = "ios")))]
 #[cfg_attr(not(feature = "nightly-docs"), cfg(target_os = "ios"))]
 pub mod ios;
@@ -56,9 +58,8 @@ mod platform {
     pub use crate::unix::*;
     #[cfg(target_os = "windows")]
     pub use crate::windows::*;
-    // #[cfg(target_os = "android")]
-    // #[path = "android/mod.rs"]
-    // mod platform;
+    #[cfg(target_os = "android")]
+    pub use crate::android::*;
     #[cfg(target_os = "ios")]
     pub use crate::ios::*;
 }

--- a/src/macos.rs
+++ b/src/macos.rs
@@ -1,4 +1,5 @@
-use core::{ptr, c_void};
+use core::ptr;
+use core::ffi::c_void;
 
 /// Raw window handle for macOS.
 ///
@@ -21,9 +22,9 @@ pub struct MacOSHandle {
 }
 
 impl MacOSHandle {
-    pub fn empty() -> MacOSHandle {
+    pub fn empty() -> Self {
         #[allow(deprecated)]
-        MacOSHandle {
+        Self {
             ns_window: ptr::null_mut(),
             ns_view: ptr::null_mut(),
             _non_exhaustive_do_not_use: crate::seal::Seal,

--- a/src/macos.rs
+++ b/src/macos.rs
@@ -1,5 +1,4 @@
-use core::ptr;
-use libc::c_void;
+use core::{ptr, c_void};
 
 /// Raw window handle for macOS.
 ///

--- a/src/unix.rs
+++ b/src/unix.rs
@@ -1,20 +1,40 @@
+use core::ffi::c_void;
 use core::ptr;
-use libc::{c_ulong, c_void};
+use libc::c_ulong;
 
-/// Raw window handle for X11.
+/// Raw window handle for Xlib.
 ///
 /// ## Construction
 /// ```
-/// # use raw_window_handle::unix::X11Handle;
-/// let handle = X11Handle {
+/// # use raw_window_handle::unix::XlibHandle;
+/// let handle = XlibHandle {
 ///     /* fields */
-///     ..X11Handle::empty()
+///     ..XlibHandle::empty()
 /// };
 /// ```
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub struct X11Handle {
+pub struct XlibHandle {
     pub window: c_ulong,
     pub display: *mut c_void,
+    #[doc(hidden)]
+    #[deprecated = "This field is used to ensure that this struct is non-exhaustive, so that it may be extended in the future. Do not refer to this field."]
+    pub _non_exhaustive_do_not_use: crate::seal::Seal,
+}
+
+/// Raw window handle for Xcb.
+///
+/// ## Construction
+/// ```
+/// # use raw_window_handle::unix::XcbHandle;
+/// let handle = XcbHandle {
+///     /* fields */
+///     ..XcbHandle::empty()
+/// };
+/// ```
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct XcbHandle {
+    pub surface: u32, // Based on xproto.h
+    pub connection: *mut c_void,
     #[doc(hidden)]
     #[deprecated = "This field is used to ensure that this struct is non-exhaustive, so that it may be extended in the future. Do not refer to this field."]
     pub _non_exhaustive_do_not_use: crate::seal::Seal,
@@ -39,10 +59,10 @@ pub struct WaylandHandle {
     pub _non_exhaustive_do_not_use: crate::seal::Seal,
 }
 
-impl X11Handle {
-    pub fn empty() -> X11Handle {
+impl XlibHandle {
+    pub fn empty() -> Self {
         #[allow(deprecated)]
-        X11Handle {
+            Self {
             window: 0,
             display: ptr::null_mut(),
             _non_exhaustive_do_not_use: crate::seal::Seal,
@@ -50,10 +70,21 @@ impl X11Handle {
     }
 }
 
-impl WaylandHandle {
-    pub fn empty() -> WaylandHandle {
+impl XcbHandle {
+    pub fn empty() -> Self {
         #[allow(deprecated)]
-        WaylandHandle {
+            Self {
+            surface: core::u32::MAX,
+            connection: ptr::null_mut(),
+            _non_exhaustive_do_not_use: crate::seal::Seal,
+        }
+    }
+}
+
+impl WaylandHandle {
+    pub fn empty() -> Self {
+        #[allow(deprecated)]
+        Self {
             surface: ptr::null_mut(),
             display: ptr::null_mut(),
             _non_exhaustive_do_not_use: crate::seal::Seal,

--- a/src/windows.rs
+++ b/src/windows.rs
@@ -1,5 +1,5 @@
+use core::ffi::c_void;
 use core::ptr;
-use libc::c_void;
 
 /// Raw window handle for Windows.
 ///


### PR DESCRIPTION
Line 36 in src/unix.rs contains the definition for the surface of a Xcb handle. I checked through xproto.h and could only see it being defined as `typedef uint32_t xcb_window_t;` for all platforms. Whether directly defining at as u32 in the Rust code is good enough is up for debate I guess. I personally think it's fine.