### PR TITLE
Draft prototype using traits

### DIFF
--- a/examples/create_surface.rs
+++ b/examples/create_surface.rs
@@ -1,0 +1,61 @@
+use raw_window_handle::HasRawWindowHandle;
+
+fn main() {}
+
+pub struct Instance {
+    // ...
+}
+
+pub struct Surface;
+
+pub enum Error {
+    NotSupported,
+}
+
+impl Instance {
+    pub fn create_surface<W: HasRawWindowHandle>(&mut self, window: &W) -> Result<Surface, Error> {
+        #[cfg(target_os = "linux")]
+        let surface = self.create_surface_for_unix(window)?;
+
+        #[cfg(target_os = "macos")]
+        let surface = self.create_surface_for_macos(window)?;
+
+        // It will intentionally not compile in other platforms
+
+        Ok(surface)
+    }
+
+    #[cfg(target_os = "linux")]
+    fn create_surface_for_unix<W: HasRawWindowHandle>(
+        &mut self,
+        window: &W,
+    ) -> Result<Surface, Error> {
+        if let Some(x11_handle) = window.x11() {
+            let _window_ptr = x11_handle.window();
+
+            // ...
+
+            Ok(Surface)
+        } else if let Some(wayland_handle) = window.wayland() {
+            let _surface_ptr = wayland_handle.surface();
+
+            // ...
+
+            Ok(Surface)
+        } else {
+            Err(Error::NotSupported)
+        }
+    }
+
+    #[cfg(target_os = "macos")]
+    fn create_surface_for_macos<W: HasRawWindowHandle>(
+        &mut self,
+        window: &W,
+    ) -> Result<Surface, Error> {
+        let _ns_window = window.ns_window();
+
+        // ...
+
+        Ok(surface)
+    }
+}

--- a/src/ios.rs
+++ b/src/ios.rs
@@ -1,34 +1,8 @@
-use core::ptr;
 use libc::c_void;
 
-/// Raw window handle for iOS.
-///
-/// ## Construction
-/// ```
-/// # use raw_window_handle::ios::IOSHandle;
-/// let handle = IOSHandle {
-///     /* fields */
-///     ..IOSHandle::empty()
-/// };
-/// ```
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub struct IOSHandle {
-    pub ui_window: *mut c_void,
-    pub ui_view: *mut c_void,
-    pub ui_view_controller: *mut c_void,
-    #[doc(hidden)]
-    #[deprecated = "This field is used to ensure that this struct is non-exhaustive, so that it may be extended in the future. Do not refer to this field."]
-    pub _non_exhaustive_do_not_use: crate::seal::Seal,
-}
-
-impl IOSHandle {
-    pub fn empty() -> IOSHandle {
-        #[allow(deprecated)]
-        IOSHandle {
-            ui_window: ptr::null_mut(),
-            ui_view: ptr::null_mut(),
-            ui_view_controller: ptr::null_mut(),
-            _non_exhaustive_do_not_use: crate::seal::Seal,
-        }
-    }
+/// Window that wraps around an iOS window handle.
+pub trait HasIOSHandle {
+    fn ui_window(&self) -> *mut c_void;
+    fn ui_view(&self) -> *mut c_void;
+    fn ui_view_controller(&self) -> *mut c_void;
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,14 +4,6 @@
 //! handle. This does not provide any utilities for creating and managing windows; instead, it
 //! provides a common interface that window creation libraries (e.g. Winit, SDL) can use to easily
 //! talk with graphics libraries (e.g. gfx-hal).
-//!
-//! ## Platform handle initialization
-//!
-//! Each platform handle struct is purposefully non-exhaustive, so that additional fields may be
-//! added without breaking backwards compatibility. Each struct provides an `empty` method that may
-//! be used along with the struct update syntax to construct it. See each specific struct for
-//! examples.
-//!
 #![cfg_attr(feature = "nightly-docs", feature(doc_cfg))]
 #![no_std]
 
@@ -66,85 +58,55 @@ mod platform {
     // mod platform;
     #[cfg(target_os = "ios")]
     pub use crate::ios::*;
+
 }
 
-/// Window that wraps around a raw window handle.
-///
-/// It is entirely valid behavior for fields within each platform-specific `RawWindowHandle` variant
-/// to be `null` or `0`, and appropriate checking should be done before the handle is used. However,
-/// users can safely assume that non-`null`/`0` fields are valid handles, and it is up to the
-/// implementor of this trait to ensure that condition is upheld.
-///
-/// The exact handle returned by `raw_window_handle` must not change during the lifetime of this
-/// trait's implementor.
-pub unsafe trait HasRawWindowHandle {
-    fn raw_window_handle(&self) -> RawWindowHandle;
+pub use _trait::HasRawWindowHandle;
+
+#[cfg(feature = "nightly-docs")]
+mod _trait {
+    /// Window that wraps around a raw window handle.
+    ///
+    /// It is entirely valid behavior for fields within each platform-specific `RawWindowHandle` variant
+    /// to be `null` or `0`, and appropriate checking should be done before the handle is used. However,
+    /// users can safely assume that non-`null`/`0` fields are valid handles, and it is up to the
+    /// implementor of this trait to ensure that condition is upheld.
+    pub unsafe trait HasRawWindowHandle {}
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub enum RawWindowHandle {
-    #[cfg_attr(feature = "nightly-docs", doc(cfg(target_os = "ios")))]
-    #[cfg_attr(not(feature = "nightly-docs"), cfg(target_os = "ios"))]
-    IOS(ios::IOSHandle),
+#[cfg(all(not(feature = "nightly-docs"), target_os = "macos"))]
+mod _trait {
+    pub unsafe trait HasRawWindowHandle: macos::HasMacOSHandle {}
 
-    #[cfg_attr(feature = "nightly-docs", doc(cfg(target_os = "macos")))]
-    #[cfg_attr(not(feature = "nightly-docs"), cfg(target_os = "macos"))]
-    MacOS(macos::MacOSHandle),
-
-    #[cfg_attr(
-        feature = "nightly-docs",
-        doc(cfg(any(
-            target_os = "linux",
-            target_os = "dragonfly",
-            target_os = "freebsd",
-            target_os = "netbsd",
-            target_os = "openbsd"
-        )))
-    )]
-    #[cfg_attr(
-        not(feature = "nightly-docs"),
-        cfg(any(
-            target_os = "linux",
-            target_os = "dragonfly",
-            target_os = "freebsd",
-            target_os = "netbsd",
-            target_os = "openbsd"
-        ))
-    )]
-    X11(unix::X11Handle),
-
-    #[cfg_attr(
-        feature = "nightly-docs",
-        doc(cfg(any(
-            target_os = "linux",
-            target_os = "dragonfly",
-            target_os = "freebsd",
-            target_os = "netbsd",
-            target_os = "openbsd"
-        )))
-    )]
-    #[cfg_attr(
-        not(feature = "nightly-docs"),
-        cfg(any(
-            target_os = "linux",
-            target_os = "dragonfly",
-            target_os = "freebsd",
-            target_os = "netbsd",
-            target_os = "openbsd"
-        ))
-    )]
-    Wayland(unix::WaylandHandle),
-
-    #[cfg_attr(feature = "nightly-docs", doc(cfg(target_os = "windows")))]
-    #[cfg_attr(not(feature = "nightly-docs"), cfg(target_os = "windows"))]
-    Windows(windows::WindowsHandle),
-
-    #[doc(hidden)]
-    #[deprecated = "This field is used to ensure that this struct is non-exhaustive, so that it may be extended in the future. Do not refer to this field."]
-    __NonExhaustiveDoNotUse(seal::Seal),
+    unsafe impl<T> HasRawWindowHandle for T where T: crate::unix::HasMacOSHandle {}
 }
 
-mod seal {
-    #[derive(Debug, Clone, Copy, PartialEq, Eq)]
-    pub struct Seal;
+#[cfg(all(
+    not(feature = "nightly-docs"),
+    any(
+        target_os = "linux",
+        target_os = "dragonfly",
+        target_os = "freebsd",
+        target_os = "netbsd",
+        target_os = "openbsd"
+    )
+))]
+mod _trait {
+    pub unsafe trait HasRawWindowHandle: crate::unix::HasUnixHandle {}
+
+    unsafe impl<T> HasRawWindowHandle for T where T: crate::unix::HasUnixHandle {}
+}
+
+#[cfg(all(not(feature = "nightly-docs"), target_os = "windows"))]
+mod _trait {
+    pub unsafe trait HasRawWindowHandle: crate::windows::HasWindowsHandle {}
+
+    unsafe impl<T> HasRawWindowHandle for T where T: crate::windows::HasWindowsHandle {}
+}
+
+#[cfg(all(not(feature = "nightly-docs"), target_os = "ios"))]
+mod _trait {
+    pub unsafe trait HasRawWindowHandle: crate::ios::HasIOSHandle {}
+
+    unsafe impl<T> HasRawWindowHandle for T where T: crate::ios::HasIOSHandle {}
 }

--- a/src/macos.rs
+++ b/src/macos.rs
@@ -1,33 +1,9 @@
-use core::ptr;
 use libc::c_void;
 
-/// Raw window handle for macOS.
-///
-/// ## Construction
-/// ```
-/// # use raw_window_handle::macos::MacOSHandle;
-/// let handle = MacOSHandle {
-///     /* fields */
-///     ..MacOSHandle::empty()
-/// };
-/// ```
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub struct MacOSHandle {
-    pub ns_window: *mut c_void,
-    pub ns_view: *mut c_void,
-    // TODO: WHAT ABOUT ns_window_controller and ns_view_controller?
-    #[doc(hidden)]
-    #[deprecated = "This field is used to ensure that this struct is non-exhaustive, so that it may be extended in the future. Do not refer to this field."]
-    pub _non_exhaustive_do_not_use: crate::seal::Seal,
-}
+/// Window that wraps around a MacOS window handle.
+pub trait HasMacOSHandle {
+    fn ns_window(&self) -> *mut c_void;
+    fn ns_view(&self) -> *mut c_void;
 
-impl MacOSHandle {
-    pub fn empty() -> MacOSHandle {
-        #[allow(deprecated)]
-        MacOSHandle {
-            ns_window: ptr::null_mut(),
-            ns_view: ptr::null_mut(),
-            _non_exhaustive_do_not_use: crate::seal::Seal,
-        }
-    }
+    // TODO: WHAT ABOUT ns_window_controller and ns_view_controller?
 }

--- a/src/unix.rs
+++ b/src/unix.rs
@@ -1,62 +1,22 @@
-use core::ptr;
 use libc::{c_ulong, c_void};
 
-/// Raw window handle for X11.
-///
-/// ## Construction
-/// ```
-/// # use raw_window_handle::unix::X11Handle;
-/// let handle = X11Handle {
-///     /* fields */
-///     ..X11Handle::empty()
-/// };
-/// ```
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub struct X11Handle {
-    pub window: c_ulong,
-    pub display: *mut c_void,
-    #[doc(hidden)]
-    #[deprecated = "This field is used to ensure that this struct is non-exhaustive, so that it may be extended in the future. Do not refer to this field."]
-    pub _non_exhaustive_do_not_use: crate::seal::Seal,
+/// Window that wraps around a Unix window handle.
+pub trait HasUnixHandle {
+    /// Try to cast this handle into an X11 handle.
+    fn x11(&self) -> Option<&dyn HasX11Handle>;
+
+    /// Try to cast this handle into a Wayland handle.
+    fn wayland(&self) -> Option<&dyn HasWaylandHandle>;
 }
 
-/// Raw window handle for Wayland.
-///
-/// ## Construction
-/// ```
-/// # use raw_window_handle::unix::WaylandHandle;
-/// let handle = WaylandHandle {
-///     /* fields */
-///     ..WaylandHandle::empty()
-/// };
-/// ```
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub struct WaylandHandle {
-    pub surface: *mut c_void,
-    pub display: *mut c_void,
-    #[doc(hidden)]
-    #[deprecated = "This field is used to ensure that this struct is non-exhaustive, so that it may be extended in the future. Do not refer to this field."]
-    pub _non_exhaustive_do_not_use: crate::seal::Seal,
+/// An X11 window.
+pub trait HasX11Handle {
+    fn window(&self) -> c_ulong;
+    fn display(&self) -> *mut c_void;
 }
 
-impl X11Handle {
-    pub fn empty() -> X11Handle {
-        #[allow(deprecated)]
-        X11Handle {
-            window: 0,
-            display: ptr::null_mut(),
-            _non_exhaustive_do_not_use: crate::seal::Seal,
-        }
-    }
-}
-
-impl WaylandHandle {
-    pub fn empty() -> WaylandHandle {
-        #[allow(deprecated)]
-        WaylandHandle {
-            surface: ptr::null_mut(),
-            display: ptr::null_mut(),
-            _non_exhaustive_do_not_use: crate::seal::Seal,
-        }
-    }
+/// A Wayland window.
+pub trait HasWaylandHandle {
+    fn surface(&self) -> *mut c_void;
+    fn display(&self) -> *mut c_void;
 }

--- a/src/windows.rs
+++ b/src/windows.rs
@@ -1,30 +1,6 @@
-use core::ptr;
 use libc::c_void;
 
-/// Raw window handle for Windows.
-///
-/// ## Construction
-/// ```
-/// # use raw_window_handle::windows::WindowsHandle;
-/// let handle = WindowsHandle {
-///     /* fields */
-///     ..WindowsHandle::empty()
-/// };
-/// ```
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub struct WindowsHandle {
-    pub hwnd: *mut c_void,
-    #[doc(hidden)]
-    #[deprecated = "This field is used to ensure that this struct is non-exhaustive, so that it may be extended in the future. Do not refer to this field."]
-    pub _non_exhaustive_do_not_use: crate::seal::Seal,
-}
-
-impl WindowsHandle {
-    pub fn empty() -> WindowsHandle {
-        #[allow(deprecated)]
-        WindowsHandle {
-            hwnd: ptr::null_mut(),
-            _non_exhaustive_do_not_use: crate::seal::Seal,
-        }
-    }
+/// Window that wraps around a Windows window handle.
+pub trait HasWindowsHandle {
+    fn hwnd(&self) -> *mut c_void;
 }


### PR DESCRIPTION
As discussed in #16, an approach using traits instead of non-exhaustive enums/structs. I also added an example showcasing how a `create_surface` implementation for MacOS and Linux would look with this approach.

This is probably a controversial change. I think we should dismiss this idea if there is no clear consensus.