### PR TITLE
Web support via stdweb and web-sys

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -46,7 +46,9 @@ pub mod windows;
 #[cfg_attr(feature = "nightly-docs", doc(cfg(target_os = "ios")))]
 #[cfg_attr(not(feature = "nightly-docs"), cfg(target_os = "ios"))]
 pub mod ios;
-// pub mod wasm;
+#[cfg_attr(feature = "nightly-docs", doc(cfg(target_arch = "wasm32")))]
+#[cfg_attr(not(feature = "nightly-docs"), cfg(target_arch = "wasm32"))]
+pub mod web;
 
 mod platform {
     #[cfg(target_os = "macos")]
@@ -66,6 +68,8 @@ mod platform {
     // mod platform;
     #[cfg(target_os = "ios")]
     pub use crate::ios::*;
+    #[cfg(target_arch = "wasm32")]
+    pub use crate::web::*;
 }
 
 /// Window that wraps around a raw window handle.
@@ -138,6 +142,10 @@ pub enum RawWindowHandle {
     #[cfg_attr(feature = "nightly-docs", doc(cfg(target_os = "windows")))]
     #[cfg_attr(not(feature = "nightly-docs"), cfg(target_os = "windows"))]
     Windows(windows::WindowsHandle),
+
+    #[cfg_attr(feature = "nightly-docs", doc(cfg(target_arch = "wasm32")))]
+    #[cfg_attr(not(feature = "nightly-docs"), cfg(target_arch = "wasm32"))]
+    Web(web::WebHandle),
 
     #[doc(hidden)]
     #[deprecated = "This field is used to ensure that this struct is non-exhaustive, so that it may be extended in the future. Do not refer to this field."]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -45,12 +45,12 @@ pub mod macos;
     ))
 )]
 pub mod unix;
-#[cfg_attr(feature = "nightly-docs", doc(cfg(target_os = "windows")))]
-#[cfg_attr(not(feature = "nightly-docs"), cfg(target_os = "windows"))]
-pub mod windows;
 #[cfg_attr(feature = "nightly-docs", doc(cfg(target_arch = "wasm32")))]
 #[cfg_attr(not(feature = "nightly-docs"), cfg(target_arch = "wasm32"))]
 pub mod web;
+#[cfg_attr(feature = "nightly-docs", doc(cfg(target_os = "windows")))]
+#[cfg_attr(not(feature = "nightly-docs"), cfg(target_os = "windows"))]
+pub mod windows;
 
 mod platform {
     #[cfg(target_os = "android")]

--- a/src/web.rs
+++ b/src/web.rs
@@ -12,6 +12,8 @@
 pub struct WebHandle {
     /// An ID value inserted into the data attributes of the canvas element as 'raw-handle'
     ///
+    /// When accessing from JS, the attribute will automatically be called rawHandle
+    ///
     /// Each canvas created by the windowing system shoudl be assigned their own unique ID.
     /// 0 should be reserved for invalid / null IDs.
     pub id: u32,

--- a/src/web.rs
+++ b/src/web.rs
@@ -1,0 +1,31 @@
+/// Raw window handle for the web
+///
+/// ## Construction
+/// ```
+/// # use raw_window_handle::web::WebHandle;
+/// let handle = WebHandle {
+///     /* fields */
+///     ..WebHandle::empty()
+/// };
+/// ```
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct WebHandle {
+    /// An ID value inserted into the data attributes of the canvas element
+    ///
+    /// Each canvas created by the windowing system shoudl be assigned their own unique ID.
+    /// 0 should be reserved for invalid / null IDs.
+    pub id: u32,
+    #[doc(hidden)]
+    #[deprecated = "This field is used to ensure that this struct is non-exhaustive, so that it may be extended in the future. Do not refer to this field."]
+    pub _non_exhaustive_do_not_use: crate::seal::Seal,
+}
+
+impl WebHandle {
+    pub fn empty() -> WebHandle {
+        #[allow(deprecated)]
+        WebHandle {
+            id: 0,
+            _non_exhaustive_do_not_use: crate::seal::Seal,
+        }
+    }
+}

--- a/src/web.rs
+++ b/src/web.rs
@@ -10,7 +10,7 @@
 /// ```
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct WebHandle {
-    /// An ID value inserted into the data attributes of the canvas element
+    /// An ID value inserted into the data attributes of the canvas element as 'raw-handle'
     ///
     /// Each canvas created by the windowing system shoudl be assigned their own unique ID.
     /// 0 should be reserved for invalid / null IDs.

--- a/src/web.rs
+++ b/src/web.rs
@@ -14,7 +14,7 @@ pub struct WebHandle {
     ///
     /// When accessing from JS, the attribute will automatically be called rawHandle
     ///
-    /// Each canvas created by the windowing system shoudl be assigned their own unique ID.
+    /// Each canvas created by the windowing system should be assigned their own unique ID.
     /// 0 should be reserved for invalid / null IDs.
     pub id: u32,
     #[doc(hidden)]


### PR DESCRIPTION
Old PR:
This will probably not be the final change, because it:

- A) will probably require bikeshedding as to the proper way to choose between stdweb / web-sys at compile time
- B) does not implement 'empty'
- C) most importantly, removes 'Copy' from the public API of the RawWindowHandle

Some aspect of web support does need to make it into raw-window-handle for web support in winit, but I wanted to put up this PR to start discussion on what that should look like.

Edit: For more context, the Canvas objects in stdweb and web-sys are Clone but not copy, so a struct containing them may not be Copy either. I'm not sure of the best-practice way to work around this.

---
New PR:

A backend-agnostic numerical ID for web has been added as an option to the window handle enum, with documentation referring users to custom data attributes on HTML elements.