### PR TITLE
Rename XcbHandle surface to window and extend documentation

### DIFF
--- a/src/android.rs
+++ b/src/android.rs
@@ -13,6 +13,7 @@ use libc::c_void;
 /// ```
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct AndroidHandle {
+    /// A pointer to an ANativeWindow.
     pub a_native_window: *mut c_void,
     #[doc(hidden)]
     #[deprecated = "This field is used to ensure that this struct is non-exhaustive, so that it may be extended in the future. Do not refer to this field."]

--- a/src/unix.rs
+++ b/src/unix.rs
@@ -13,7 +13,9 @@ use libc::{c_ulong, c_void};
 /// ```
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct XlibHandle {
+    /// An Xlib `Window`.
     pub window: c_ulong,
+    /// A pointer to an Xlib `Display`.
     pub display: *mut c_void,
     #[doc(hidden)]
     #[deprecated = "This field is used to ensure that this struct is non-exhaustive, so that it may be extended in the future. Do not refer to this field."]
@@ -32,7 +34,9 @@ pub struct XlibHandle {
 /// ```
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct XcbHandle {
-    pub surface: u32, // Based on xproto.h
+    /// An X11 `xcb_window_t`.
+    pub window: u32, // Based on xproto.h
+    /// A pointer to an X server `xcb_connection_t`.
     pub connection: *mut c_void,
     #[doc(hidden)]
     #[deprecated = "This field is used to ensure that this struct is non-exhaustive, so that it may be extended in the future. Do not refer to this field."]
@@ -51,7 +55,9 @@ pub struct XcbHandle {
 /// ```
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct WaylandHandle {
+    /// A pointer to a `wl_surface`.
     pub surface: *mut c_void,
+    /// A pointer to a `wl_display`.
     pub display: *mut c_void,
     #[doc(hidden)]
     #[deprecated = "This field is used to ensure that this struct is non-exhaustive, so that it may be extended in the future. Do not refer to this field."]
@@ -73,7 +79,7 @@ impl XcbHandle {
     pub fn empty() -> XcbHandle {
         #[allow(deprecated)]
         XcbHandle {
-            surface: 0,
+            window: 0,
             connection: ptr::null_mut(),
             _non_exhaustive_do_not_use: crate::seal::Seal,
         }

--- a/src/windows.rs
+++ b/src/windows.rs
@@ -13,6 +13,7 @@ use libc::c_void;
 /// ```
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct WindowsHandle {
+    /// A Win32 HWND handle.
     pub hwnd: *mut c_void,
     #[doc(hidden)]
     #[deprecated = "This field is used to ensure that this struct is non-exhaustive, so that it may be extended in the future. Do not refer to this field."]


### PR DESCRIPTION
Should solve possible confusion due to the usage of base types.

Fixes https://github.com/rust-windowing/raw-window-handle/issues/11