### PR TITLE
Various soundness fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+# Unreleased
+
+* Remove `RawWindowHandle`'s `HasRawWindowHandle` implementation, as it was unsound (see [#35](https://github.com/rust-windowing/raw-window-handle/issues/35))
+* Explicitly require that handles within `RawWindowHandle` be valid for the lifetime of the `HasRawWindowHandle` implementation that provided them.
+
 # 0.3.0 (2019-10-5)
 
 * **Breaking:** Rename `XLib.surface` to `XLib.window`, as that more accurately represents the underlying type.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -76,26 +76,22 @@ mod platform {
 
 /// Window that wraps around a raw window handle.
 ///
-/// It is entirely valid behavior for fields within each platform-specific `RawWindowHandle` variant
-/// to be `null` or `0`, and appropriate checking should be done before the handle is used. However,
-/// users can safely assume that non-`null`/`0` fields are valid handles, and it is up to the
-/// implementor of this trait to ensure that condition is upheld.
+/// # Safety guarantees
 ///
-/// Despite that qualification, implementors should still make a best-effort attempt to fill in all
+/// Users can safely assume that non-`null`/`0` fields are valid handles, and it is up to the
+/// implementer of this trait to ensure that condition is upheld. However, It is entirely valid
+/// behavior for fields within each platform-specific `RawWindowHandle` variant to be `null` or
+/// `0`, and appropriate checking should be done before the handle is used.
+///
+/// Despite that qualification, implementers should still make a best-effort attempt to fill in all
 /// available fields. If an implementation doesn't, and a downstream user needs the field, it should
-/// try to derive the field from other fields the implementor *does* provide via whatever methods the
+/// try to derive the field from other fields the implementer *does* provide via whatever methods the
 /// platform provides.
 ///
-/// The exact handle returned by `raw_window_handle` must not change during the lifetime of this
-/// trait's implementor.
+/// The exact handles returned by `raw_window_handle` must remain consistent between multiple calls
+/// to `raw_window_handle`, and must be valid for at least the the implementer's lifetime.
 pub unsafe trait HasRawWindowHandle {
     fn raw_window_handle(&self) -> RawWindowHandle;
-}
-
-unsafe impl HasRawWindowHandle for RawWindowHandle {
-    fn raw_window_handle(&self) -> RawWindowHandle {
-        *self
-    }
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -89,7 +89,8 @@ mod platform {
 /// platform provides.
 ///
 /// The exact handles returned by `raw_window_handle` must remain consistent between multiple calls
-/// to `raw_window_handle`, and must be valid for at least the the implementer's lifetime.
+/// to `raw_window_handle`, and must be valid for at least the lifetime of the `HasRawWindowHandle`
+/// implementer.
 pub unsafe trait HasRawWindowHandle {
     fn raw_window_handle(&self) -> RawWindowHandle;
 }


### PR DESCRIPTION
Reverts #29 and requires that `RawWindowHandle`s be valid for the lifetime of the `HasRawWindowHandle` implementer. Closes #35.