### PR TITLE
Derive Hash implementation

### DIFF
--- a/src/ios.rs
+++ b/src/ios.rs
@@ -11,7 +11,7 @@ use libc::c_void;
 ///     ..IOSHandle::empty()
 /// };
 /// ```
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub struct IOSHandle {
     pub ui_window: *mut c_void,
     pub ui_view: *mut c_void,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -95,7 +95,7 @@ pub unsafe trait HasRawWindowHandle {
     fn raw_window_handle(&self) -> RawWindowHandle;
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub enum RawWindowHandle {
     #[cfg_attr(feature = "nightly-docs", doc(cfg(target_os = "ios")))]
     #[cfg_attr(not(feature = "nightly-docs"), cfg(target_os = "ios"))]
@@ -189,6 +189,6 @@ pub enum RawWindowHandle {
 }
 
 mod seal {
-    #[derive(Debug, Clone, Copy, PartialEq, Eq)]
+    #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
     pub struct Seal;
 }

--- a/src/macos.rs
+++ b/src/macos.rs
@@ -11,7 +11,7 @@ use libc::c_void;
 ///     ..MacOSHandle::empty()
 /// };
 /// ```
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub struct MacOSHandle {
     pub ns_window: *mut c_void,
     pub ns_view: *mut c_void,

--- a/src/unix.rs
+++ b/src/unix.rs
@@ -11,7 +11,7 @@ use libc::{c_ulong, c_void};
 ///     ..XlibHandle::empty()
 /// };
 /// ```
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub struct XlibHandle {
     /// An Xlib `Window`.
     pub window: c_ulong,
@@ -32,7 +32,7 @@ pub struct XlibHandle {
 ///     ..XcbHandle::empty()
 /// };
 /// ```
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub struct XcbHandle {
     /// An X11 `xcb_window_t`.
     pub window: u32, // Based on xproto.h
@@ -53,7 +53,7 @@ pub struct XcbHandle {
 ///     ..WaylandHandle::empty()
 /// };
 /// ```
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub struct WaylandHandle {
     /// A pointer to a `wl_surface`.
     pub surface: *mut c_void,

--- a/src/web.rs
+++ b/src/web.rs
@@ -8,7 +8,7 @@
 ///     ..WebHandle::empty()
 /// };
 /// ```
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub struct WebHandle {
     /// An ID value inserted into the data attributes of the canvas element as 'raw-handle'
     ///

--- a/src/windows.rs
+++ b/src/windows.rs
@@ -11,7 +11,7 @@ use libc::c_void;
 ///     ..WindowsHandle::empty()
 /// };
 /// ```
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub struct WindowsHandle {
     /// A Win32 HWND handle.
     pub hwnd: *mut c_void,


### PR DESCRIPTION
There is no reason for `RawWindowHandle` not to implement it, as it contains only integers and raw pointers. It already implements `Eq`, so it would be possible to store handles in a `HashMap`, which is what I needed in my code.