### PR TITLE
Add Hash to Android Handle

### DIFF
--- a/src/android.rs
+++ b/src/android.rs
@@ -11,7 +11,7 @@ use libc::c_void;
 ///     ..AndroidHandle::empty()
 /// };
 /// ```
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub struct AndroidHandle {
     /// A pointer to an ANativeWindow.
     pub a_native_window: *mut c_void,


### PR DESCRIPTION
 Small PR, Android Handle was missed in https://github.com/rust-windowing/raw-window-handle/pull/39 so does not compile on Android.