### PR TITLE
Remove _non_exhaustive fields to use #[non_exhaustive] macro

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Unreleased
 
 * **Breaking:** Change type for pointers, which may be null, to `Option<NonNull<_>>`.
+* **Breaking** Remove `_do_not_use` tags to use `#[non_exhaustive]` macro
 
 # 0.3.3 (2019-12-1)
 

--- a/src/android.rs
+++ b/src/android.rs
@@ -11,21 +11,17 @@ use core::ptr::NonNull;
 ///     ..AndroidHandle::empty()
 /// };
 /// ```
+#[non_exhaustive]
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub struct AndroidHandle {
     /// A pointer to an ANativeWindow.
     pub a_native_window: Option<NonNull<c_void>>,
-    #[doc(hidden)]
-    #[deprecated = "This field is used to ensure that this struct is non-exhaustive, so that it may be extended in the future. Do not refer to this field."]
-    pub _non_exhaustive_do_not_use: crate::seal::Seal,
 }
 
 impl AndroidHandle {
     pub fn empty() -> AndroidHandle {
-        #[allow(deprecated)]
         AndroidHandle {
             a_native_window: None,
-            _non_exhaustive_do_not_use: crate::seal::Seal,
         }
     }
 }

--- a/src/android.rs
+++ b/src/android.rs
@@ -6,10 +6,8 @@ use core::ptr::NonNull;
 /// ## Construction
 /// ```
 /// # use raw_window_handle::android::AndroidHandle;
-/// let handle = AndroidHandle {
-///     /* fields */
-///     ..AndroidHandle::empty()
-/// };
+/// let mut handle = AndroidHandle::empty();
+///  /* set fields */
 /// ```
 #[non_exhaustive]
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]

--- a/src/ios.rs
+++ b/src/ios.rs
@@ -6,10 +6,8 @@ use core::ptr::NonNull;
 /// ## Construction
 /// ```
 /// # use raw_window_handle::ios::IOSHandle;
-/// let handle = IOSHandle {
-///     /* fields */
-///     ..IOSHandle::empty()
-/// };
+/// let mut handle = IOSHandle::empty();
+/// /* set fields */
 /// ```
 #[non_exhaustive]
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]

--- a/src/ios.rs
+++ b/src/ios.rs
@@ -11,24 +11,20 @@ use core::ptr::NonNull;
 ///     ..IOSHandle::empty()
 /// };
 /// ```
+#[non_exhaustive]
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub struct IOSHandle {
     pub ui_window: Option<NonNull<c_void>>,
     pub ui_view: Option<NonNull<c_void>>,
     pub ui_view_controller: Option<NonNull<c_void>>,
-    #[doc(hidden)]
-    #[deprecated = "This field is used to ensure that this struct is non-exhaustive, so that it may be extended in the future. Do not refer to this field."]
-    pub _non_exhaustive_do_not_use: crate::seal::Seal,
 }
 
 impl IOSHandle {
     pub fn empty() -> IOSHandle {
-        #[allow(deprecated)]
         IOSHandle {
             ui_window: None,
             ui_view: None,
             ui_view_controller: None,
-            _non_exhaustive_do_not_use: crate::seal::Seal,
         }
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -100,6 +100,7 @@ pub unsafe trait HasRawWindowHandle {
     fn raw_window_handle(&self) -> RawWindowHandle;
 }
 
+#[non_exhaustive]
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub enum RawWindowHandle {
     #[cfg_attr(feature = "nightly-docs", doc(cfg(target_os = "ios")))]
@@ -195,15 +196,6 @@ pub enum RawWindowHandle {
     #[cfg_attr(feature = "nightly-docs", doc(cfg(target_os = "android")))]
     #[cfg_attr(not(feature = "nightly-docs"), cfg(target_os = "android"))]
     Android(android::AndroidHandle),
-
-    #[doc(hidden)]
-    #[deprecated = "This field is used to ensure that this struct is non-exhaustive, so that it may be extended in the future. Do not refer to this field."]
-    __NonExhaustiveDoNotUse(seal::Seal),
-}
-
-mod seal {
-    #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
-    pub struct Seal;
 }
 
 /// This wraps a [`RawWindowHandle`] to give it a [`HasRawWindowHandle`] impl.

--- a/src/macos.rs
+++ b/src/macos.rs
@@ -6,10 +6,8 @@ use core::ptr::NonNull;
 /// ## Construction
 /// ```
 /// # use raw_window_handle::macos::MacOSHandle;
-/// let handle = MacOSHandle {
-///     /* fields */
-///     ..MacOSHandle::empty()
-/// };
+/// let mut handle = MacOSHandle::empty();
+/// /* set fields */
 /// ```
 #[non_exhaustive]
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]

--- a/src/macos.rs
+++ b/src/macos.rs
@@ -11,23 +11,19 @@ use core::ptr::NonNull;
 ///     ..MacOSHandle::empty()
 /// };
 /// ```
+#[non_exhaustive]
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub struct MacOSHandle {
     pub ns_window: Option<NonNull<c_void>>,
     pub ns_view: Option<NonNull<c_void>>,
     // TODO: WHAT ABOUT ns_window_controller and ns_view_controller?
-    #[doc(hidden)]
-    #[deprecated = "This field is used to ensure that this struct is non-exhaustive, so that it may be extended in the future. Do not refer to this field."]
-    pub _non_exhaustive_do_not_use: crate::seal::Seal,
 }
 
 impl MacOSHandle {
     pub fn empty() -> MacOSHandle {
-        #[allow(deprecated)]
         MacOSHandle {
             ns_window: None,
             ns_view: None,
-            _non_exhaustive_do_not_use: crate::seal::Seal,
         }
     }
 }

--- a/src/redox.rs
+++ b/src/redox.rs
@@ -6,27 +6,20 @@ use libc::c_void;
 /// ## Construction
 /// ```
 /// # use raw_window_handle::redox::RedoxHandle;
-/// let handle = RedoxHandle {
-///     /* fields */
-///     ..RedoxHandle::empty()
-/// };
+/// let mut handle = RedoxHandle::empty()
+///  /* set fields */
 /// ```
+#[non_exhaustive]
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub struct RedoxHandle {
     /// A pointer to an orbclient window.
     pub window: *mut c_void,
-
-    #[doc(hidden)]
-    #[deprecated = "This field is used to ensure that this struct is non-exhaustive, so that it may be extended in the future. Do not refer to this field."]
-    pub _non_exhaustive_do_not_use: crate::seal::Seal,
 }
 
 impl RedoxHandle {
     pub fn empty() -> RedoxHandle {
-        #[allow(deprecated)]
         RedoxHandle {
             window: ptr::null_mut(),
-            _non_exhaustive_do_not_use: crate::seal::Seal,
         }
     }
 }

--- a/src/unix.rs
+++ b/src/unix.rs
@@ -8,10 +8,8 @@ use cty::c_ulong;
 /// ## Construction
 /// ```
 /// # use raw_window_handle::unix::XlibHandle;
-/// let handle = XlibHandle {
-///     /* fields */
-///     ..XlibHandle::empty()
-/// };
+/// let handle = XlibHandle::empty();
+/// /* set fields */
 /// ```
 #[non_exhaustive]
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
@@ -27,10 +25,8 @@ pub struct XlibHandle {
 /// ## Construction
 /// ```
 /// # use raw_window_handle::unix::XcbHandle;
-/// let handle = XcbHandle {
-///     /* fields */
-///     ..XcbHandle::empty()
-/// };
+/// let handle = XcbHandle::empty();
+/// /* set fields */
 /// ```
 #[non_exhaustive]
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
@@ -46,10 +42,8 @@ pub struct XcbHandle {
 /// ## Construction
 /// ```
 /// # use raw_window_handle::unix::WaylandHandle;
-/// let handle = WaylandHandle {
-///     /* fields */
-///     ..WaylandHandle::empty()
-/// };
+/// let handle = WaylandHandle::empty();
+/// /* set fields */
 /// ```
 #[non_exhaustive]
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]

--- a/src/unix.rs
+++ b/src/unix.rs
@@ -13,15 +13,13 @@ use cty::c_ulong;
 ///     ..XlibHandle::empty()
 /// };
 /// ```
+#[non_exhaustive]
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub struct XlibHandle {
     /// An Xlib `Window`.
     pub window: c_ulong,
     /// A pointer to an Xlib `Display`.
     pub display: *mut c_void,
-    #[doc(hidden)]
-    #[deprecated = "This field is used to ensure that this struct is non-exhaustive, so that it may be extended in the future. Do not refer to this field."]
-    pub _non_exhaustive_do_not_use: crate::seal::Seal,
 }
 
 /// Raw window handle for Xcb.
@@ -34,15 +32,13 @@ pub struct XlibHandle {
 ///     ..XcbHandle::empty()
 /// };
 /// ```
+#[non_exhaustive]
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub struct XcbHandle {
     /// An X11 `xcb_window_t`.
     pub window: u32, // Based on xproto.h
     /// A pointer to an X server `xcb_connection_t`.
     pub connection: *mut c_void,
-    #[doc(hidden)]
-    #[deprecated = "This field is used to ensure that this struct is non-exhaustive, so that it may be extended in the future. Do not refer to this field."]
-    pub _non_exhaustive_do_not_use: crate::seal::Seal,
 }
 
 /// Raw window handle for Wayland.
@@ -55,46 +51,38 @@ pub struct XcbHandle {
 ///     ..WaylandHandle::empty()
 /// };
 /// ```
+#[non_exhaustive]
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub struct WaylandHandle {
     /// A pointer to a `wl_surface`.
     pub surface: *mut c_void,
     /// A pointer to a `wl_display`.
     pub display: *mut c_void,
-    #[doc(hidden)]
-    #[deprecated = "This field is used to ensure that this struct is non-exhaustive, so that it may be extended in the future. Do not refer to this field."]
-    pub _non_exhaustive_do_not_use: crate::seal::Seal,
 }
 
 impl XlibHandle {
     pub fn empty() -> XlibHandle {
-        #[allow(deprecated)]
         XlibHandle {
             window: 0,
             display: ptr::null_mut(),
-            _non_exhaustive_do_not_use: crate::seal::Seal,
         }
     }
 }
 
 impl XcbHandle {
     pub fn empty() -> XcbHandle {
-        #[allow(deprecated)]
         XcbHandle {
             window: 0,
             connection: ptr::null_mut(),
-            _non_exhaustive_do_not_use: crate::seal::Seal,
         }
     }
 }
 
 impl WaylandHandle {
     pub fn empty() -> WaylandHandle {
-        #[allow(deprecated)]
         WaylandHandle {
             surface: ptr::null_mut(),
             display: ptr::null_mut(),
-            _non_exhaustive_do_not_use: crate::seal::Seal,
         }
     }
 }

--- a/src/web.rs
+++ b/src/web.rs
@@ -8,6 +8,7 @@
 ///     ..WebHandle::empty()
 /// };
 /// ```
+#[non_exhaustive]
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub struct WebHandle {
     /// An ID value inserted into the data attributes of the canvas element as 'raw-handle'
@@ -17,17 +18,10 @@ pub struct WebHandle {
     /// Each canvas created by the windowing system should be assigned their own unique ID.
     /// 0 should be reserved for invalid / null IDs.
     pub id: u32,
-    #[doc(hidden)]
-    #[deprecated = "This field is used to ensure that this struct is non-exhaustive, so that it may be extended in the future. Do not refer to this field."]
-    pub _non_exhaustive_do_not_use: crate::seal::Seal,
 }
 
 impl WebHandle {
     pub fn empty() -> WebHandle {
-        #[allow(deprecated)]
-        WebHandle {
-            id: 0,
-            _non_exhaustive_do_not_use: crate::seal::Seal,
-        }
+        WebHandle { id: 0 }
     }
 }

--- a/src/web.rs
+++ b/src/web.rs
@@ -3,10 +3,8 @@
 /// ## Construction
 /// ```
 /// # use raw_window_handle::web::WebHandle;
-/// let handle = WebHandle {
-///     /* fields */
-///     ..WebHandle::empty()
-/// };
+/// let mut handle = WebHandle::empty();
+/// /* set fields */
 /// ```
 #[non_exhaustive]
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]

--- a/src/windows.rs
+++ b/src/windows.rs
@@ -6,10 +6,8 @@ use core::ptr::NonNull;
 /// ## Construction
 /// ```
 /// # use raw_window_handle::windows::WindowsHandle;
-/// let handle = WindowsHandle {
-///     /* fields */
-///     ..WindowsHandle::empty()
-/// };
+/// let mut handle = WindowsHandle::empty();
+/// /* set fields */
 /// ```
 #[non_exhaustive]
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]

--- a/src/windows.rs
+++ b/src/windows.rs
@@ -11,24 +11,20 @@ use core::ptr::NonNull;
 ///     ..WindowsHandle::empty()
 /// };
 /// ```
+#[non_exhaustive]
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub struct WindowsHandle {
     /// A Win32 HWND handle.
     pub hwnd: Option<NonNull<c_void>>,
     /// The HINSTANCE associated with this type's HWND.
     pub hinstance: Option<NonNull<c_void>>,
-    #[doc(hidden)]
-    #[deprecated = "This field is used to ensure that this struct is non-exhaustive, so that it may be extended in the future. Do not refer to this field."]
-    pub _non_exhaustive_do_not_use: crate::seal::Seal,
 }
 
 impl WindowsHandle {
     pub fn empty() -> WindowsHandle {
-        #[allow(deprecated)]
         WindowsHandle {
             hwnd: None,
             hinstance: None,
-            _non_exhaustive_do_not_use: crate::seal::Seal,
         }
     }
 }


### PR DESCRIPTION
Remove `_non_exhaustive` fields and replace them with the new `#[non_exhaustive]` macro

### Pros 
- Disallow users to use this field anyway, which limit future breaking changes
- Cleaner

### Cons
- Rust version support is reduced to 1.40+ (I didn't see any notice about that so it may be fine)
- Breaking change
- Disallow `let handle = Handle { /* fields */ ..Handle::empty() };` syntax

Maybe provide a `Handle::new(...)` function for each type ?
