### PR TITLE
Remove the dependency on libc

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,9 +14,6 @@ documentation = "https://docs.rs/raw-window-handle"
 travis-ci = { repository = "rust-windowing/raw-window-handle" }
 appveyor = { repository = "rust-windowing/raw-window-handle" }
 
-[dependencies]
-libc = {version="0.2", features=[]}
-
 [features]
 nightly-docs = []
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,6 +10,9 @@ keywords = ["windowing"]
 readme = "README.md"
 documentation = "https://docs.rs/raw-window-handle"
 
+[dependencies]
+cty = "0.2"
+
 [badges]
 travis-ci = { repository = "rust-windowing/raw-window-handle" }
 appveyor = { repository = "rust-windowing/raw-window-handle" }

--- a/src/android.rs
+++ b/src/android.rs
@@ -1,5 +1,5 @@
+use core::ffi::c_void;
 use core::ptr;
-use libc::c_void;
 
 /// Raw window handle for Android.
 ///

--- a/src/ios.rs
+++ b/src/ios.rs
@@ -1,5 +1,5 @@
+use core::ffi::c_void;
 use core::ptr;
-use libc::c_void;
 
 /// Raw window handle for iOS.
 ///

--- a/src/macos.rs
+++ b/src/macos.rs
@@ -1,5 +1,5 @@
+use core::ffi::c_void;
 use core::ptr;
-use libc::c_void;
 
 /// Raw window handle for macOS.
 ///

--- a/src/unix.rs
+++ b/src/unix.rs
@@ -1,10 +1,7 @@
 use core::ffi::c_void;
 use core::ptr;
 
-#[cfg(any(windows, target_pointer_width = "32"))]
-pub type c_ulong = u32;
-#[cfg(not(any(windows, target_pointer_width = "32")))]
-pub type c_ulong = u64;
+use cty::c_ulong;
 
 /// Raw window handle for Xlib.
 ///

--- a/src/unix.rs
+++ b/src/unix.rs
@@ -1,5 +1,10 @@
+use core::ffi::c_void;
 use core::ptr;
-use libc::{c_ulong, c_void};
+
+#[cfg(any(windows, target_pointer_width = "32"))]
+pub type c_ulong = u32;
+#[cfg(not(any(windows, target_pointer_width = "32")))]
+pub type c_ulong = u64;
 
 /// Raw window handle for Xlib.
 ///

--- a/src/windows.rs
+++ b/src/windows.rs
@@ -1,5 +1,5 @@
+use core::ffi::c_void;
 use core::ptr;
-use libc::c_void;
 
 /// Raw window handle for Windows.
 ///


### PR DESCRIPTION
This PR completely removes the dependency on `libc`.

It was used to get a `c_void` type, but core::ffi::c_void is sufficient.

It was also used to get `c_ulong`, but we can simply define the type ourselves in the one location that requires it.

Closes https://github.com/rust-windowing/raw-window-handle/issues/3