### PR TITLE
add TrustedHandle type

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -215,7 +215,7 @@ impl TrustedHandle {
         Self { raw }
     }
 }
-unsafe impl HasRawWindowHandle {
+unsafe impl HasRawWindowHandle for TrustedHandle {
     fn raw_window_handle(&self) -> RawWindowHandle {
         self.raw
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -202,10 +202,10 @@ mod seal {
 ///
 /// The solution is that you assert that you're trusting a particular handle
 /// value by (unsafely) placing it within this wrapper struct.
-pub struct TrustedHandle {
+pub struct TrustedWindowHandle {
     raw: RawWindowHandle,
 }
-impl TrustedHandle {
+impl TrustedWindowHandle {
     /// Assert that the `RawWindowHandle` value can be trusted.
     ///
     /// ## Safety
@@ -215,7 +215,7 @@ impl TrustedHandle {
         Self { raw }
     }
 }
-unsafe impl HasRawWindowHandle for TrustedHandle {
+unsafe impl HasRawWindowHandle for TrustedWindowHandle {
     fn raw_window_handle(&self) -> RawWindowHandle {
         self.raw
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -192,3 +192,31 @@ mod seal {
     #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
     pub struct Seal;
 }
+
+/// This wraps a [`RawWindowHandle`] to give it a [`HasRawWindowHandle`] impl.
+///
+/// The `HasRawWindowHandle` trait must be an `unsafe` trait because *other*
+/// unsafe code is going to rely on it to provide accurate window handle info.
+/// Since `RawWindowHandle` is an enum and enum fields are public, anyone could
+/// make any random `RawWindowHandle` value in safe code.
+///
+/// The solution is that you assert that you're trusting a particular handle
+/// value by (unsafely) placing it within this wrapper struct.
+pub struct TrustedHandle {
+    raw: RawWindowHandle,
+}
+impl TrustedHandle {
+    /// Assert that the `RawWindowHandle` value can be trusted.
+    ///
+    /// ## Safety
+    /// If the value violates any of the safety outlines given in the
+    /// [`HasRawWindowHandle`] trait this can lead to UB.
+    pub const unsafe fn new(raw: RawWindowHandle) -> Self {
+        Self { raw }
+    }
+}
+unsafe impl HasRawWindowHandle {
+    fn raw_window_handle(&self) -> RawWindowHandle {
+        self.raw
+    }
+}


### PR DESCRIPTION
Add a wrapper to mark when a specific raw window handle is to be trusted.

Closes https://github.com/rust-windowing/raw-window-handle/issues/49