### PR TITLE
Allow `ios` handles to be used under target_os = "tvos"

### DIFF
--- a/src/ios.rs
+++ b/src/ios.rs
@@ -1,7 +1,8 @@
 use core::ffi::c_void;
 use core::ptr;
 
-/// Raw window handle for iOS.
+/// Raw window handle for IOS and other platforms using UIKit-based windowing
+/// (tvOS, Mac Catalyst (`*-ios-macabi` targets), and, in theory, watchOS).
 ///
 /// ## Construction
 /// ```

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -18,8 +18,14 @@
 #[cfg_attr(feature = "nightly-docs", doc(cfg(target_os = "android")))]
 #[cfg_attr(not(feature = "nightly-docs"), cfg(target_os = "android"))]
 pub mod android;
-#[cfg_attr(feature = "nightly-docs", doc(cfg(target_os = "ios")))]
-#[cfg_attr(not(feature = "nightly-docs"), cfg(target_os = "ios"))]
+#[cfg_attr(
+    feature = "nightly-docs",
+    doc(cfg(any(target_os = "ios", target_os = "tvos")))
+)]
+#[cfg_attr(
+    not(feature = "nightly-docs"),
+    cfg(any(target_os = "ios", target_os = "tvos"))
+)]
 pub mod ios;
 #[cfg_attr(feature = "nightly-docs", doc(cfg(target_os = "macos")))]
 #[cfg_attr(not(feature = "nightly-docs"), cfg(target_os = "macos"))]
@@ -68,7 +74,7 @@ mod platform {
     #[cfg(target_os = "windows")]
     pub use crate::windows::*;
     // mod platform;
-    #[cfg(target_os = "ios")]
+    #[cfg(any(target_os = "ios", target_os = "tvos"))]
     pub use crate::ios::*;
     #[cfg(target_arch = "wasm32")]
     pub use crate::web::*;
@@ -97,8 +103,14 @@ pub unsafe trait HasRawWindowHandle {
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub enum RawWindowHandle {
-    #[cfg_attr(feature = "nightly-docs", doc(cfg(target_os = "ios")))]
-    #[cfg_attr(not(feature = "nightly-docs"), cfg(target_os = "ios"))]
+    #[cfg_attr(
+        feature = "nightly-docs",
+        doc(cfg(any(target_os = "ios", target_os = "tvos")))
+    )]
+    #[cfg_attr(
+        not(feature = "nightly-docs"),
+        cfg(any(target_os = "ios", target_os = "tvos"))
+    )]
     IOS(ios::IOSHandle),
 
     #[cfg_attr(feature = "nightly-docs", doc(cfg(target_os = "macos")))]


### PR DESCRIPTION
I think in an ideal world the handle would be `uikit::UIKitHandle` (not `ios::IOSHandle`) and the variant would be `RawWindowHandle::UIKit` (not `RawWindowHandle::IOS`). The 2nd of these can't be added backwards compatibly (short of using [semver-trick](https://github.com/dtolnay/semver-trick) shenanigans).

This probably holds true for `macos` (should be `appkit`) since the catalyst targets (`*-ios-macabi`, which are `target_os = "ios"`) can use AppKit (in addition to UIKit), although I doubt any Rust code does this.

All that said, the renaming suggestions are just food for thought for when 1.0.0 happens tho, since it will probably need to use the semver-trick anyway to avoid ecosystem fragmentation, but is a opportunity to fix imperfect naming choices like this.