### PR TITLE
Remove cfg guards as suggested in #63.

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -15,63 +15,20 @@
 #![cfg_attr(feature = "nightly-docs", feature(doc_cfg))]
 #![no_std]
 
-#[cfg_attr(feature = "nightly-docs", doc(cfg(target_os = "android")))]
-#[cfg_attr(not(feature = "nightly-docs"), cfg(target_os = "android"))]
 pub mod android;
-#[cfg_attr(feature = "nightly-docs", doc(cfg(target_os = "ios")))]
-#[cfg_attr(not(feature = "nightly-docs"), cfg(target_os = "ios"))]
 pub mod ios;
-#[cfg_attr(feature = "nightly-docs", doc(cfg(target_os = "macos")))]
-#[cfg_attr(not(feature = "nightly-docs"), cfg(target_os = "macos"))]
 pub mod macos;
-#[cfg_attr(
-    feature = "nightly-docs",
-    doc(cfg(any(
-        target_os = "linux",
-        target_os = "dragonfly",
-        target_os = "freebsd",
-        target_os = "netbsd",
-        target_os = "openbsd"
-    )))
-)]
-#[cfg_attr(
-    not(feature = "nightly-docs"),
-    cfg(any(
-        target_os = "linux",
-        target_os = "dragonfly",
-        target_os = "freebsd",
-        target_os = "netbsd",
-        target_os = "openbsd"
-    ))
-)]
 pub mod unix;
-#[cfg_attr(feature = "nightly-docs", doc(cfg(target_arch = "wasm32")))]
-#[cfg_attr(not(feature = "nightly-docs"), cfg(target_arch = "wasm32"))]
 pub mod web;
-#[cfg_attr(feature = "nightly-docs", doc(cfg(target_os = "windows")))]
-#[cfg_attr(not(feature = "nightly-docs"), cfg(target_os = "windows"))]
 pub mod windows;
 
 mod platform {
-    #[cfg(target_os = "android")]
     pub use crate::android::*;
-    #[cfg(target_os = "macos")]
-    pub use crate::macos::*;
-    #[cfg(any(
-        target_os = "linux",
-        target_os = "dragonfly",
-        target_os = "freebsd",
-        target_os = "netbsd",
-        target_os = "openbsd"
-    ))]
-    pub use crate::unix::*;
-    #[cfg(target_os = "windows")]
-    pub use crate::windows::*;
-    // mod platform;
-    #[cfg(target_os = "ios")]
     pub use crate::ios::*;
-    #[cfg(target_arch = "wasm32")]
+    pub use crate::macos::*;
+    pub use crate::unix::*;
     pub use crate::web::*;
+    pub use crate::windows::*;
 }
 
 /// Window that wraps around a raw window handle.
@@ -95,92 +52,70 @@ pub unsafe trait HasRawWindowHandle {
     fn raw_window_handle(&self) -> RawWindowHandle;
 }
 
+/// A "raw" handle to some specific window library or system.
+///
+/// # Variant Availability
+///
+/// Note that all variants are present on all targets (none are disabled behind
+/// `#[cfg]`s), but see the "Availability Hints" section on each variant for
+/// some hints on where this variant might be expected.
+///
+/// Note that these "Availability Hints" are not normative. That is to say, a
+/// [`HasRawWindowHandle`] implementor is completely allowed to return something
+/// unexpected. (For example, it's legal for someone to return a
+/// [`RawWindowHandle::Xlib`] on macOS, it would just be weird, and probably
+/// requires something like XQuartz be used).
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub enum RawWindowHandle {
-    #[cfg_attr(feature = "nightly-docs", doc(cfg(target_os = "ios")))]
-    #[cfg_attr(not(feature = "nightly-docs"), cfg(target_os = "ios"))]
+    /// A raw window handle for UIKit (Apple's non-macOS windowing library).
+    ///
+    /// # Availability Hints
+    /// This variant is likely to be used on iOS, tvOS, (in theory) watchOS, and
+    /// Mac Catalyst (`$arch-apple-ios-macabi` targets, which can notably use
+    /// UIKit *or* AppKit), as these are the targets that (currently) support
+    /// UIKit.
     IOS(ios::IOSHandle),
-
-    #[cfg_attr(feature = "nightly-docs", doc(cfg(target_os = "macos")))]
-    #[cfg_attr(not(feature = "nightly-docs"), cfg(target_os = "macos"))]
+    /// A raw window handle for AppKit.
+    ///
+    /// # Availability Hints
+    /// This variant is likely to be used on macOS, although Mac Catalyst
+    /// (`$arch-apple-ios-macabi` targets, which can notably use UIKit *or*
+    /// AppKit) can also use it despite being `target_os = "ios"`.
     MacOS(macos::MacOSHandle),
-
-    #[cfg_attr(
-        feature = "nightly-docs",
-        doc(cfg(any(
-            target_os = "linux",
-            target_os = "dragonfly",
-            target_os = "freebsd",
-            target_os = "netbsd",
-            target_os = "openbsd"
-        )))
-    )]
-    #[cfg_attr(
-        not(feature = "nightly-docs"),
-        cfg(any(
-            target_os = "linux",
-            target_os = "dragonfly",
-            target_os = "freebsd",
-            target_os = "netbsd",
-            target_os = "openbsd"
-        ))
-    )]
+    /// A raw window handle for Xlib.
+    ///
+    /// # Availability Hints
+    /// This variant is likely to show up anywhere someone manages to get X11
+    /// working that Xlib can be built for, which is to say, most (but not all)
+    /// Unix systems.
     Xlib(unix::XlibHandle),
-
-    #[cfg_attr(
-        feature = "nightly-docs",
-        doc(cfg(any(
-            target_os = "linux",
-            target_os = "dragonfly",
-            target_os = "freebsd",
-            target_os = "netbsd",
-            target_os = "openbsd"
-        )))
-    )]
-    #[cfg_attr(
-        not(feature = "nightly-docs"),
-        cfg(any(
-            target_os = "linux",
-            target_os = "dragonfly",
-            target_os = "freebsd",
-            target_os = "netbsd",
-            target_os = "openbsd"
-        ))
-    )]
+    /// A raw window handle for Xcb.
+    ///
+    /// # Availability Hints
+    /// This variant is likely to show up anywhere someone manages to get X11
+    /// working that XCB can be built for, which is to say, most (but not all)
+    /// Unix systems.
     Xcb(unix::XcbHandle),
-
-    #[cfg_attr(
-        feature = "nightly-docs",
-        doc(cfg(any(
-            target_os = "linux",
-            target_os = "dragonfly",
-            target_os = "freebsd",
-            target_os = "netbsd",
-            target_os = "openbsd"
-        )))
-    )]
-    #[cfg_attr(
-        not(feature = "nightly-docs"),
-        cfg(any(
-            target_os = "linux",
-            target_os = "dragonfly",
-            target_os = "freebsd",
-            target_os = "netbsd",
-            target_os = "openbsd"
-        ))
-    )]
+    /// A raw window handle for Wayland.
+    ///
+    /// # Availability Hints
+    /// This variant should be expected anywhere Wayland works, which is
+    /// currently some subset of unix systems.
     Wayland(unix::WaylandHandle),
-
-    #[cfg_attr(feature = "nightly-docs", doc(cfg(target_os = "windows")))]
-    #[cfg_attr(not(feature = "nightly-docs"), cfg(target_os = "windows"))]
+    /// A raw window handle for Windows.
+    ///
+    /// # Availibility Hints
+    /// This variant is used on windows systems.
     Windows(windows::WindowsHandle),
-
-    #[cfg_attr(feature = "nightly-docs", doc(cfg(target_arch = "wasm32")))]
-    #[cfg_attr(not(feature = "nightly-docs"), cfg(target_arch = "wasm32"))]
+    /// A raw window handle for the web.
+    ///
+    /// # Availibility Hints
+    /// This variant is used on wasm or asmjs targets when targeting the web/html5.
     Web(web::WebHandle),
-
-    #[cfg_attr(feature = "nightly-docs", doc(cfg(target_os = "android")))]
-    #[cfg_attr(not(feature = "nightly-docs"), cfg(target_os = "android"))]
+    /// A raw window handle for Android.
+    ///
+    /// # Availibility Hints
+    /// This variant is used on android targets.
     Android(android::AndroidHandle),
 
     #[doc(hidden)]


### PR DESCRIPTION
Fixes #63, closes #62 (which it makes irrelevant).

It's entirely non-breaking, as the enum is non-exhaustive already.