### PR TITLE
Get ready for 0.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 * **Breaking:** Change type for pointers, which may be null, to `Option<NonNull<_>>`.
 * **Breaking** Remove `_do_not_use` tags to use `#[non_exhaustive]` macro
+* Added `TrustedWindowHandle::from_has_raw_window_handle`.
 
 # 0.3.3 (2019-12-1)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,43 +1,46 @@
-# Unreleased
+# Changelog
+
+## 0.4.0 (?)
 
 * **Breaking:** Change type for pointers, which may be null, to `Option<NonNull<_>>`.
-* **Breaking** Remove `_do_not_use` tags to use `#[non_exhaustive]` macro
+* **Breaking:** Remove `_do_not_use` tags to use `#[non_exhaustive]` macro
 * Added `TrustedWindowHandle::from_has_raw_window_handle`.
+* **Breaking:** handle variants are no longer cfg-guarded by platform.
 
-# 0.3.3 (2019-12-1)
+## 0.3.3 (2019-12-1)
 
 * Add missing `Hash` implementation for `AndroidHandle`.
 
-# 0.3.2 (2019-11-29)
+## 0.3.2 (2019-11-29)
 
 * Add `Hash` implementation for `RawWindowHandle`.
 
-# 0.3.1 (2019-10-27)
+## 0.3.1 (2019-10-27)
 
 * Remove `RawWindowHandle`'s `HasRawWindowHandle` implementation, as it was unsound (see [#35](https://github.com/rust-windowing/raw-window-handle/issues/35))
 * Explicitly require that handles within `RawWindowHandle` be valid for the lifetime of the `HasRawWindowHandle` implementation that provided them.
 
-# 0.3.0 (2019-10-5)
+## 0.3.0 (2019-10-5)
 
 * **Breaking:** Rename `XLib.surface` to `XLib.window`, as that more accurately represents the underlying type.
 * Implement `HasRawWindowHandle` for `RawWindowHandle`
 * Add `HINSTANCE` field to `WindowsHandle`.
 
-# 0.2.0 (2019-09-26)
+## 0.2.0 (2019-09-26)
 
 * **Breaking:** Rename `X11` to `XLib`.
 * Add XCB support.
 * Add Web support.
 * Add Android support.
 
-# 0.1.2 (2019-08-13)
+## 0.1.2 (2019-08-13)
 
 * Fix use of private `_non_exhaustive` field in platform handle structs preventing structs from getting initialized.
 
-# 0.1.1 (2019-08-13)
+## 0.1.1 (2019-08-13)
 
 * Flesh out Cargo.toml, adding crates.io info rendering tags.
 
-# 0.1.0 (2019-08-13)
+## 0.1.0 (2019-08-13)
 
 * Initial release.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "raw-window-handle"
-version = "0.3.3"
+version = "0.4.0-alpha.0"
 authors = ["Osspial <osspial@gmail.com>"]
 edition = "2018"
 description = "Interoperability library for Rust Windowing applications."

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,9 +16,3 @@ cty = "0.2"
 [badges]
 travis-ci = { repository = "rust-windowing/raw-window-handle" }
 appveyor = { repository = "rust-windowing/raw-window-handle" }
-
-[features]
-nightly-docs = []
-
-[package.metadata.docs.rs]
-features = ["nightly-docs"]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,3 +1,5 @@
+#![no_std]
+
 //! Interoperability library for Rust Windowing applications.
 //!
 //! This library provides standard types for accessing a window's platform-specific raw window
@@ -11,76 +13,14 @@
 //! added without breaking backwards compatibility. Each struct provides an `empty` method that may
 //! be used along with the struct update syntax to construct it. See each specific struct for
 //! examples.
-//!
-#![cfg_attr(feature = "nightly-docs", feature(doc_cfg))]
-#![no_std]
 
-#[cfg_attr(feature = "nightly-docs", doc(cfg(target_os = "android")))]
-#[cfg_attr(not(feature = "nightly-docs"), cfg(target_os = "android"))]
 pub mod android;
-#[cfg_attr(feature = "nightly-docs", doc(cfg(target_os = "ios")))]
-#[cfg_attr(not(feature = "nightly-docs"), cfg(target_os = "ios"))]
 pub mod ios;
-#[cfg_attr(feature = "nightly-docs", doc(cfg(target_os = "macos")))]
-#[cfg_attr(not(feature = "nightly-docs"), cfg(target_os = "macos"))]
 pub mod macos;
-#[cfg_attr(feature = "nightly-docs", doc(cfg(target_os = "redox")))]
-#[cfg_attr(not(feature = "nightly-docs"), cfg(target_os = "redox"))]
 pub mod redox;
-#[cfg_attr(
-    feature = "nightly-docs",
-    doc(cfg(any(
-        target_os = "linux",
-        target_os = "dragonfly",
-        target_os = "freebsd",
-        target_os = "netbsd",
-        target_os = "openbsd",
-        target_os = "solaris"
-    )))
-)]
-#[cfg_attr(
-    not(feature = "nightly-docs"),
-    cfg(any(
-        target_os = "linux",
-        target_os = "dragonfly",
-        target_os = "freebsd",
-        target_os = "netbsd",
-        target_os = "openbsd",
-        target_os = "solaris"
-    ))
-)]
 pub mod unix;
-#[cfg_attr(feature = "nightly-docs", doc(cfg(target_arch = "wasm32")))]
-#[cfg_attr(not(feature = "nightly-docs"), cfg(target_arch = "wasm32"))]
 pub mod web;
-#[cfg_attr(feature = "nightly-docs", doc(cfg(target_os = "windows")))]
-#[cfg_attr(not(feature = "nightly-docs"), cfg(target_os = "windows"))]
 pub mod windows;
-
-mod platform {
-    #[cfg(target_os = "android")]
-    pub use crate::android::*;
-    #[cfg(target_os = "macos")]
-    pub use crate::macos::*;
-    #[cfg(target_os = "redox")]
-    pub use crate::redox::*;
-    #[cfg(any(
-        target_os = "linux",
-        target_os = "dragonfly",
-        target_os = "freebsd",
-        target_os = "netbsd",
-        target_os = "openbsd",
-        target_os = "solaris",
-    ))]
-    pub use crate::unix::*;
-    #[cfg(target_os = "windows")]
-    pub use crate::windows::*;
-    // mod platform;
-    #[cfg(target_os = "ios")]
-    pub use crate::ios::*;
-    #[cfg(target_arch = "wasm32")]
-    pub use crate::web::*;
-}
 
 /// Window that wraps around a raw window handle.
 ///
@@ -100,101 +40,26 @@ pub unsafe trait HasRawWindowHandle {
     fn raw_window_handle(&self) -> RawWindowHandle;
 }
 
+/// An enum to simply combine the different possible raw window handle variants.
 #[non_exhaustive]
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub enum RawWindowHandle {
-    #[cfg_attr(feature = "nightly-docs", doc(cfg(target_os = "ios")))]
-    #[cfg_attr(not(feature = "nightly-docs"), cfg(target_os = "ios"))]
     IOS(ios::IOSHandle),
 
-    #[cfg_attr(feature = "nightly-docs", doc(cfg(target_os = "macos")))]
-    #[cfg_attr(not(feature = "nightly-docs"), cfg(target_os = "macos"))]
     MacOS(macos::MacOSHandle),
 
-    #[cfg_attr(feature = "nightly-docs", doc(cfg(target_os = "redox")))]
-    #[cfg_attr(not(feature = "nightly-docs"), cfg(target_os = "redox"))]
     Redox(redox::RedoxHandle),
 
-    #[cfg_attr(
-        feature = "nightly-docs",
-        doc(cfg(any(
-            target_os = "linux",
-            target_os = "dragonfly",
-            target_os = "freebsd",
-            target_os = "netbsd",
-            target_os = "openbsd",
-            target_os = "solaris"
-        )))
-    )]
-    #[cfg_attr(
-        not(feature = "nightly-docs"),
-        cfg(any(
-            target_os = "linux",
-            target_os = "dragonfly",
-            target_os = "freebsd",
-            target_os = "netbsd",
-            target_os = "openbsd",
-            target_os = "solaris"
-        ))
-    )]
     Xlib(unix::XlibHandle),
 
-    #[cfg_attr(
-        feature = "nightly-docs",
-        doc(cfg(any(
-            target_os = "linux",
-            target_os = "dragonfly",
-            target_os = "freebsd",
-            target_os = "netbsd",
-            target_os = "openbsd",
-            target_os = "solaris"
-        )))
-    )]
-    #[cfg_attr(
-        not(feature = "nightly-docs"),
-        cfg(any(
-            target_os = "linux",
-            target_os = "dragonfly",
-            target_os = "freebsd",
-            target_os = "netbsd",
-            target_os = "openbsd",
-            target_os = "solaris"
-        ))
-    )]
     Xcb(unix::XcbHandle),
 
-    #[cfg_attr(
-        feature = "nightly-docs",
-        doc(cfg(any(
-            target_os = "linux",
-            target_os = "dragonfly",
-            target_os = "freebsd",
-            target_os = "netbsd",
-            target_os = "openbsd"
-        )))
-    )]
-    #[cfg_attr(
-        not(feature = "nightly-docs"),
-        cfg(any(
-            target_os = "linux",
-            target_os = "dragonfly",
-            target_os = "freebsd",
-            target_os = "netbsd",
-            target_os = "openbsd"
-        ))
-    )]
     Wayland(unix::WaylandHandle),
 
-    #[cfg_attr(feature = "nightly-docs", doc(cfg(target_os = "windows")))]
-    #[cfg_attr(not(feature = "nightly-docs"), cfg(target_os = "windows"))]
     Windows(windows::WindowsHandle),
 
-    #[cfg_attr(feature = "nightly-docs", doc(cfg(target_arch = "wasm32")))]
-    #[cfg_attr(not(feature = "nightly-docs"), cfg(target_arch = "wasm32"))]
     Web(web::WebHandle),
 
-    #[cfg_attr(feature = "nightly-docs", doc(cfg(target_os = "android")))]
-    #[cfg_attr(not(feature = "nightly-docs"), cfg(target_os = "android"))]
     Android(android::AndroidHandle),
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -211,13 +211,23 @@ pub struct TrustedWindowHandle {
     raw: RawWindowHandle,
 }
 impl TrustedWindowHandle {
-    /// Assert that the `RawWindowHandle` value can be trusted.
+    /// Assert that the [`RawWindowHandle`] value can be trusted.
     ///
     /// ## Safety
     /// If the value violates any of the safety outlines given in the
     /// [`HasRawWindowHandle`] trait this can lead to UB.
     pub const unsafe fn new(raw: RawWindowHandle) -> Self {
         Self { raw }
+    }
+
+    /// Read from a [`HasRawWindowHandle`] into being a trusted value.
+    pub fn from_has_raw_window_handle<H: HasRawWindowHandle>(fr: &H) -> Self {
+        // Safety: Because `HasRawWindowHandle` is an unsafe trait, we can trust
+        // that it gives a correct handle. If not, the fault lies with the trait
+        // implementation, not this function.
+        Self {
+            raw: fr.raw_window_handle(),
+        }
     }
 }
 unsafe impl HasRawWindowHandle for TrustedWindowHandle {

--- a/src/redox.rs
+++ b/src/redox.rs
@@ -6,7 +6,7 @@ use core::ptr;
 /// ## Construction
 /// ```
 /// # use raw_window_handle::redox::RedoxHandle;
-/// let mut handle = RedoxHandle::empty()
+/// let mut handle = RedoxHandle::empty();
 ///  /* set fields */
 /// ```
 #[non_exhaustive]

--- a/src/redox.rs
+++ b/src/redox.rs
@@ -1,5 +1,5 @@
+use core::ffi::c_void;
 use core::ptr;
-use libc::c_void;
 
 /// Raw window handle for Redox OS.
 ///


### PR DESCRIPTION
We've got some breaking changes building up and it's time to move to a 0.4

* [ ] TODO: There's some docs in the related PR from Thomcc that we should incorporate here.
* [ ] TODO: we need to rename ios to uikit and macos to appkit, since you can use the macos types on target_os="ios" (via catalyst) and the ios types on target_os!="ios" (tvos, for example)

---
* Closes https://github.com/rust-windowing/raw-window-handle/issues/63
* Closes https://github.com/rust-windowing/raw-window-handle/issues/60
* Closes https://github.com/rust-windowing/raw-window-handle/issues/58
