### PR TITLE
Add WinRT CoreWindow handle

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -189,6 +189,10 @@ pub enum RawWindowHandle {
     #[cfg_attr(not(feature = "nightly-docs"), cfg(target_os = "windows"))]
     Windows(windows::WindowsHandle),
 
+    #[cfg_attr(feature = "nightly-docs", doc(cfg(target_os = "windows")))]
+    #[cfg_attr(not(feature = "nightly-docs"), cfg(target_os = "windows"))]
+    WinRT(windows::WinRTHandle),
+
     #[cfg_attr(feature = "nightly-docs", doc(cfg(target_arch = "wasm32")))]
     #[cfg_attr(not(feature = "nightly-docs"), cfg(target_arch = "wasm32"))]
     Web(web::WebHandle),

--- a/src/windows.rs
+++ b/src/windows.rs
@@ -44,8 +44,6 @@ pub struct WinRTHandle {
 
 impl WinRTHandle {
     pub fn empty() -> WinRTHandle {
-        WinRTHandle {
-            core_window: None,
-        }
+        WinRTHandle { core_window: None }
     }
 }

--- a/src/windows.rs
+++ b/src/windows.rs
@@ -26,3 +26,26 @@ impl WindowsHandle {
         }
     }
 }
+
+/// Raw window handle for WinRT.
+///
+/// ## Construction
+/// ```
+/// # use raw_window_handle::windows::WinRTHandle;
+/// let mut handle = WinRTHandle::empty();
+/// /* set fields */
+/// ```
+#[non_exhaustive]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub struct WinRTHandle {
+    /// A WinRT CoreWindow handle.
+    pub core_window: Option<NonNull<c_void>>,
+}
+
+impl WinRTHandle {
+    pub fn empty() -> WinRTHandle {
+        WinRTHandle {
+            core_window: None,
+        }
+    }
+}


### PR DESCRIPTION
Currently this crate lacks an entry for Windows WinRT, which uses CoreWindow instead of HWND and other Win32 stuff for handling the windowing.

This pull request implements the `WinRT` variant on `RawWindowHandle`, holding ` WinRTHandle` struct. The `WinRTHandle` struct currently has a single member, `core_window`, which is intended to contain a pointer to a `CoreWindow` instance. This implementation is chosen to match SDL2 which also exposes only the `CoreWindow`, and because it is the minimum currently needed for creating a swapchain on DX12 under WinRT [see here](https://docs.microsoft.com/en-us/windows/win32/api/dxgi1_2/nf-dxgi1_2-idxgifactory2-createswapchainforcorewindow).

I just copy pasted the existing `Windows` variant, renamed it and replaced the struct members.