### PR TITLE
Alleviate the need for ecosystem-wide upgrading to 0.4.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Unreleased
 
+* Add `HasRawWindowHandle` implementation for `HasRawWindowHandle` in the newer
+  version `0.4.1`.
+
+  This allows "provider" crates that implement `HasRawWindowHandle` (like
+  `winit`, `sdl2`, `glfw`, `fltk`, ...) to upgrade to `v0.4.1` without a
+  breaking change.
+
+  Afterwards "consumer" crates (like `gfx`, `wgpu`, `rfd`, ...) can start
+  upgrading with minimal breakage for their users.
+
 # 0.3.3 (2019-12-1)
 
 * Add missing `Hash` implementation for `AndroidHandle`.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,6 +16,7 @@ appveyor = { repository = "rust-windowing/raw-window-handle" }
 
 [dependencies]
 libc = {version="0.2", features=[]}
+new = { version = "0.4.1", package = "raw-window-handle" }
 
 [features]
 nightly-docs = []

--- a/src/android.rs
+++ b/src/android.rs
@@ -29,3 +29,12 @@ impl AndroidHandle {
         }
     }
 }
+
+impl From<new::AndroidNdkHandle> for AndroidHandle {
+    fn from(handle: new::AndroidNdkHandle) -> Self {
+        Self {
+            a_native_window: handle.a_native_window,
+            ..Self::empty()
+        }
+    }
+}

--- a/src/ios.rs
+++ b/src/ios.rs
@@ -32,3 +32,14 @@ impl IOSHandle {
         }
     }
 }
+
+impl From<new::UiKitHandle> for IOSHandle {
+    fn from(handle: new::UiKitHandle) -> Self {
+        Self {
+            ui_window: handle.ui_window,
+            ui_view: handle.ui_view,
+            ui_view_controller: handle.ui_view_controller,
+            ..Self::empty()
+        }
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -95,6 +95,65 @@ pub unsafe trait HasRawWindowHandle {
     fn raw_window_handle(&self) -> RawWindowHandle;
 }
 
+unsafe impl<T: new::HasRawWindowHandle> HasRawWindowHandle for T {
+    fn raw_window_handle(&self) -> RawWindowHandle {
+        match new::HasRawWindowHandle::raw_window_handle(self) {
+            #[cfg(target_os = "ios")]
+            new::RawWindowHandle::UiKit(handle) => {
+                RawWindowHandle::IOS(handle.into())
+            }
+            #[cfg(target_os = "macos")]
+            new::RawWindowHandle::AppKit(handle) => {
+                RawWindowHandle::MacOS(handle.into())
+            }
+            #[cfg(any(
+                target_os = "linux",
+                target_os = "dragonfly",
+                target_os = "freebsd",
+                target_os = "netbsd",
+                target_os = "openbsd"
+            ))]
+            new::RawWindowHandle::Xlib(handle) => {
+                RawWindowHandle::Xlib(handle.into())
+            }
+            #[cfg(any(
+                target_os = "linux",
+                target_os = "dragonfly",
+                target_os = "freebsd",
+                target_os = "netbsd",
+                target_os = "openbsd"
+            ))]
+            new::RawWindowHandle::Xcb(handle) => {
+                RawWindowHandle::Xcb(handle.into())
+            }
+            #[cfg(any(
+                target_os = "linux",
+                target_os = "dragonfly",
+                target_os = "freebsd",
+                target_os = "netbsd",
+                target_os = "openbsd"
+            ))]
+            new::RawWindowHandle::Wayland(handle) => {
+                RawWindowHandle::Wayland(handle.into())
+            }
+            #[cfg(target_os = "windows")]
+            new::RawWindowHandle::Win32(handle) => {
+                RawWindowHandle::Windows(handle.into())
+            }
+            #[cfg(target_arch = "wasm32")]
+            new::RawWindowHandle::Web(handle) => {
+                RawWindowHandle::Web(handle.into())
+            }
+            #[cfg(target_os = "android")]
+            new::RawWindowHandle::AndroidNdk(handle) => {
+                RawWindowHandle::Android(handle.into())
+            }
+            _ => panic!("Invalid handle for this platform. Please update raw-window-handle to > 0.4.1!")
+        }
+    }
+}
+
+
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub enum RawWindowHandle {
     #[cfg_attr(feature = "nightly-docs", doc(cfg(target_os = "ios")))]

--- a/src/macos.rs
+++ b/src/macos.rs
@@ -31,3 +31,13 @@ impl MacOSHandle {
         }
     }
 }
+
+impl From<new::AppKitHandle> for MacOSHandle {
+    fn from(handle: new::AppKitHandle) -> Self {
+        Self {
+            ns_window: handle.ns_window,
+            ns_view: handle.ns_view,
+            ..Self::empty()
+        }
+    }
+}

--- a/src/unix.rs
+++ b/src/unix.rs
@@ -96,3 +96,33 @@ impl WaylandHandle {
         }
     }
 }
+
+impl From<new::XlibHandle> for XlibHandle {
+    fn from(handle: new::XlibHandle) -> Self {
+        Self {
+            window: handle.window,
+            display: handle.display,
+            ..Self::empty()
+        }
+    }
+}
+
+impl From<new::XcbHandle> for XcbHandle {
+    fn from(handle: new::XcbHandle) -> Self {
+        Self {
+            window: handle.window,
+            connection: handle.connection,
+            ..Self::empty()
+        }
+    }
+}
+
+impl From<new::WaylandHandle> for WaylandHandle {
+    fn from(handle: new::WaylandHandle) -> Self {
+        Self {
+            surface: handle.surface,
+            display: handle.display,
+            ..Self::empty()
+        }
+    }
+}

--- a/src/web.rs
+++ b/src/web.rs
@@ -31,3 +31,12 @@ impl WebHandle {
         }
     }
 }
+
+impl From<new::WebHandle> for WebHandle {
+    fn from(handle: new::WebHandle) -> Self {
+        Self {
+            id: handle.id,
+            ..Self::empty()
+        }
+    }
+}

--- a/src/windows.rs
+++ b/src/windows.rs
@@ -32,3 +32,13 @@ impl WindowsHandle {
         }
     }
 }
+
+impl From<new::Win32Handle> for WindowsHandle {
+    fn from(handle: new::Win32Handle) -> Self {
+        Self {
+            hwnd: handle.hwnd,
+            hinstance: handle.hinstance,
+            ..Self::empty()
+        }
+    }
+}


### PR DESCRIPTION
~This PR is opened against `master`, but in reality it should be merged into 5207e99a5872e06de2807f556222d056703af44a.~

Using the [semver trick](https://github.com/dtolnay/semver-trick), we can make upgrading from `0.3` to `0.4.1` much less painful!
We simply add a `v0.3` `HasRawWindowHandle` impl for a `v0.4.1` `HasRawWindowHandle`, and release `v0.3.4`.

The idea is that this will allow crates whose purpose is to provide an `HasRawWindowHandle` implementation to upgrade first (e.g. `winit`, `sdl2`, `glfw`, `fltk`, ...). When a sufficient amount of "provider" crates have upgraded, "consumer" crates (e.g. `gfx`, `wgpu`, `rfd`, ...) can safely start upgrading while minimizing breakage for downstream users.