### PR TITLE
Allow unsized handle types for `Arc` and `Rc`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 # Changelog
 
-## 0.4.1 (?)
+## 0.4.2 (?)
+
+* Also implement `HasRawWindowHandle` for `Rc<T>`, and `Arc<T>` where `T: ?Sized`.
+
+## 0.4.1 (2021-11-19)
 
 * Added an impl of `HasRawWindowHandle` for `&T`, `Rc<T>`, and `Arc<T>`. The impls for `Rc<T>` and `Arc<T>` require the `alloc` feature.
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -55,19 +55,20 @@ pub unsafe trait HasRawWindowHandle {
     fn raw_window_handle(&self) -> RawWindowHandle;
 }
 
+// TODO: Lower bound to `T: ?Sized` in a breaking release
 unsafe impl<'a, T: HasRawWindowHandle> HasRawWindowHandle for &'a T {
     fn raw_window_handle(&self) -> RawWindowHandle {
         (*self).raw_window_handle()
     }
 }
 #[cfg(feature = "alloc")]
-unsafe impl<T: HasRawWindowHandle> HasRawWindowHandle for alloc::rc::Rc<T> {
+unsafe impl<T: HasRawWindowHandle + ?Sized> HasRawWindowHandle for alloc::rc::Rc<T> {
     fn raw_window_handle(&self) -> RawWindowHandle {
         (**self).raw_window_handle()
     }
 }
 #[cfg(feature = "alloc")]
-unsafe impl<T: HasRawWindowHandle> HasRawWindowHandle for alloc::sync::Arc<T> {
+unsafe impl<T: HasRawWindowHandle + ?Sized> HasRawWindowHandle for alloc::sync::Arc<T> {
     fn raw_window_handle(&self) -> RawWindowHandle {
         (**self).raw_window_handle()
     }


### PR DESCRIPTION
Lower bounds of `HasRawWindowHandle` impls of `Arc` and `Rc` to allow unsized types.

This allows to use eg `Arc<dyn HasRawWindowHandle + Send + Sync>`, which is nice to avoid generics.

However this is not done on references because it is a fundamental type, so lowering the bound is a breaking change.