### PR TITLE
Release `v0.3.4`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,10 @@
-# Unreleased
+# 0.3.4 (2021-11-27)
 
-* Add `HasRawWindowHandle` implementation for `HasRawWindowHandle` in the newer
-  version `0.4.1`.
+* Add `HasRawWindowHandle` implementation for `HasRawWindowHandle` in the
+  newer `v0.4`.
 
   This allows "provider" crates that implement `HasRawWindowHandle` (like
-  `winit`, `sdl2`, `glfw`, `fltk`, ...) to upgrade to `v0.4.1` without a
+  `winit`, `sdl2`, `glfw`, `fltk`, ...) to upgrade to `v0.4` without a
   breaking change.
 
   Afterwards "consumer" crates (like `gfx`, `wgpu`, `rfd`, ...) can start

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "raw-window-handle"
-version = "0.3.3"
+version = "0.3.4"
 authors = ["Osspial <osspial@gmail.com>"]
 edition = "2018"
 description = "Interoperability library for Rust Windowing applications."


### PR DESCRIPTION
Release `v0.3.4`, which includes the semver trick to make upgrading to `v0.4` easier.

See https://github.com/rust-windowing/raw-window-handle/pull/74#issuecomment-974023212 for more info.

I'll try to keep the changelog date updated in case you, @Lokathor, don't have time to release it today.