### PR TITLE
Document `HasRawWindowHandle` impl for `Arc` and `Rc` on docs.rs

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,3 +19,7 @@ cty = "0.2"
 [badges]
 travis-ci = { repository = "rust-windowing/raw-window-handle" }
 appveyor = { repository = "rust-windowing/raw-window-handle" }
+
+[package.metadata.docs.rs]
+all-features = true
+rustdoc-args = ["--cfg", "docsrs"]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,5 +1,7 @@
 #![no_std]
 
+#![cfg_attr(docsrs, feature(doc_cfg))]
+
 //! Interoperability library for Rust Windowing applications.
 //!
 //! This library provides standard types for accessing a window's platform-specific raw window
@@ -61,12 +63,14 @@ unsafe impl<'a, T: HasRawWindowHandle + ?Sized> HasRawWindowHandle for &'a T {
     }
 }
 #[cfg(feature = "alloc")]
+#[cfg_attr(docsrs, doc(cfg(feature = "alloc")))]
 unsafe impl<T: HasRawWindowHandle + ?Sized> HasRawWindowHandle for alloc::rc::Rc<T> {
     fn raw_window_handle(&self) -> RawWindowHandle {
         (**self).raw_window_handle()
     }
 }
 #[cfg(feature = "alloc")]
+#[cfg_attr(docsrs, doc(cfg(feature = "alloc")))]
 unsafe impl<T: HasRawWindowHandle + ?Sized> HasRawWindowHandle for alloc::sync::Arc<T> {
     fn raw_window_handle(&self) -> RawWindowHandle {
         (**self).raw_window_handle()


### PR DESCRIPTION
Closes #77 

Test with

```sh
RUSTDOCFLAGS='--cfg docsrs' cargo +nightly rustdoc --all-features
```