### PR TITLE
Add visual IDs to X11 handles

### DIFF
--- a/src/unix.rs
+++ b/src/unix.rs
@@ -18,6 +18,8 @@ pub struct XlibHandle {
     pub window: c_ulong,
     /// A pointer to an Xlib `Display`.
     pub display: *mut c_void,
+    /// An Xlib visual ID, or 0 if unknown.
+    pub visual_id: c_ulong,
 }
 
 /// Raw window handle for Xcb.
@@ -35,6 +37,8 @@ pub struct XcbHandle {
     pub window: u32, // Based on xproto.h
     /// A pointer to an X server `xcb_connection_t`.
     pub connection: *mut c_void,
+    /// An X11 `xcb_visualid_t`, or 0 if unknown.
+    pub visual_id: u32,
 }
 
 /// Raw window handle for Wayland.
@@ -59,6 +63,7 @@ impl XlibHandle {
         Self {
             window: 0,
             display: ptr::null_mut(),
+            visual_id: 0,
         }
     }
 }
@@ -68,6 +73,7 @@ impl XcbHandle {
         Self {
             window: 0,
             connection: ptr::null_mut(),
+            visual_id: 0,
         }
     }
 }


### PR DESCRIPTION
Needed for Vulkan physical device presentation support queries (e.g. [`vkGetPhysicalDeviceXlibPresentationSupportKHR`](https://khronos.org/registry/vulkan/specs/1.2-extensions/man/html/vkGetPhysicalDeviceXlibPresentationSupportKHR.html)).

I'm not sure what, if anything, would be a sensible default value for these that won't cause fallout if someone tries to use it. Do we try to solve that problem in general?