### PR TITLE
add haiku support

### DIFF
--- a/src/haiku.rs
+++ b/src/haiku.rs
@@ -1,0 +1,28 @@
+use core::ffi::c_void;
+use core::ptr;
+
+/// Raw window handle for Haiku.
+///
+/// ## Construction
+/// ```
+/// # use raw_window_handle::HaikuHandle;
+/// let mut handle = HaikuHandle::empty();
+/// /* set fields */
+/// ```
+#[non_exhaustive]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub struct HaikuHandle {
+    /// A pointer to a BWindow object
+    pub b_window: *mut c_void,
+    /// A pointer to a BDirectWindow object
+    pub b_direct_window: *mut c_void,
+}
+
+impl HaikuHandle {
+    pub fn empty() -> Self {
+        Self {
+            b_window: ptr::null_mut(),
+            b_direct_window: ptr::null_mut(),
+        }
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -30,6 +30,7 @@ mod uikit;
 mod unix;
 mod web;
 mod windows;
+mod haiku;
 
 pub use android::AndroidNdkHandle;
 pub use appkit::AppKitHandle;
@@ -38,6 +39,7 @@ pub use uikit::UiKitHandle;
 pub use unix::{WaylandHandle, XcbHandle, XlibHandle};
 pub use web::WebHandle;
 pub use windows::{Win32Handle, WinRtHandle};
+pub use haiku::HaikuHandle;
 
 /// Window that wraps around a raw window handle.
 ///
@@ -154,4 +156,9 @@ pub enum RawWindowHandle {
     /// ## Availability Hints
     /// This variant is used on Android targets.
     AndroidNdk(AndroidNdkHandle),
+    /// A raw window handle for Haiku.
+    ///
+    /// ## Availability Hints
+    /// This variant is used on HaikuOS.
+    Haiku(HaikuHandle),
 }


### PR DESCRIPTION
this pr adds haiku support (BWindow and BDirectWindow)

the following is an example run of tests on a haiku instance:


```
> uname -a
Haiku shredder 1 hrev55602 Oct 29 2021 07:10:38 x86_64 x86_64 Haiku

> cargo test
   Compiling cty v0.2.1
   Compiling raw-window-handle v0.4.2 (/boot/home/src/git/rust-libs/raw-window-handle)
    Finished test [unoptimized + debuginfo] target(s) in 1.76s
     Running unittests (target/debug/deps/raw_window_handle-c16f3ff9cf02e130)

running 0 tests

test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s

   Doc-tests raw-window-handle

running 11 tests
test src/android.rs - android::AndroidNdkHandle (line 7) ... ok
test src/haiku.rs - haiku::HaikuHandle (line 7) ... ok
test src/redox.rs - redox::OrbitalHandle (line 7) ... ok
test src/appkit.rs - appkit::AppKitHandle (line 7) ... ok
test src/windows.rs - windows::WinRtHandle (line 33) ... ok
test src/unix.rs - unix::XlibHandle (line 9) ... ok
test src/windows.rs - windows::Win32Handle (line 7) ... ok
test src/web.rs - web::WebHandle (line 4) ... ok
test src/uikit.rs - uikit::UiKitHandle (line 7) ... ok
test src/unix.rs - unix::XcbHandle (line 28) ... ok
test src/unix.rs - unix::WaylandHandle (line 47) ... ok

test result: ok. 11 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 2.08s

```