### PR TITLE
Make implementors of HasRawWindowHandle v0.5 also implement v0.4's

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Changelog
 
+## 0.4.4 (2022-08-10)
+
+* Add `HasRawWindowHandle` implementation for `HasRawWindowHandle` +
+  `HasRawDisplayHandle` in the newer version `0.5.0`.
+
+  This allows "provider" crates that implement `HasRawWindowHandle` (like
+  `winit`, `sdl2`, `glfw`, `fltk`, ...) to upgrade to `v0.5.0` immediately.
+
+  Afterwards "consumer" crates (like `gfx`, `wgpu`, `rfd`, ...) can start
+  upgrading with minimal breakage for their users.
+
 ## 0.4.3 (2022-03-29)
 
 * [Add visual IDs to X11 handles](https://github.com/rust-windowing/raw-window-handle/pull/83)

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "raw-window-handle"
-version = "0.4.3"
+version = "0.4.4"
 authors = ["Osspial <osspial@gmail.com>"]
 edition = "2018"
 description = "Interoperability library for Rust Windowing applications."
@@ -11,10 +11,11 @@ readme = "README.md"
 documentation = "https://docs.rs/raw-window-handle"
 
 [features]
-alloc = []
+alloc = ["new/alloc"]
 
 [dependencies]
 cty = "0.2"
+new = { version = "0.5.0", package = "raw-window-handle" }
 
 [badges]
 travis-ci = { repository = "rust-windowing/raw-window-handle" }

--- a/src/android.rs
+++ b/src/android.rs
@@ -23,3 +23,12 @@ impl AndroidNdkHandle {
         }
     }
 }
+
+impl From<new::AndroidNdkWindowHandle> for AndroidNdkHandle {
+    fn from(handle: new::AndroidNdkWindowHandle) -> Self {
+        Self {
+            a_native_window: handle.a_native_window,
+            ..Self::empty()
+        }
+    }
+}

--- a/src/appkit.rs
+++ b/src/appkit.rs
@@ -27,3 +27,13 @@ impl AppKitHandle {
         }
     }
 }
+
+impl From<new::AppKitWindowHandle> for AppKitHandle {
+    fn from(handle: new::AppKitWindowHandle) -> Self {
+        Self {
+            ns_window: handle.ns_window,
+            ns_view: handle.ns_view,
+            ..Self::empty()
+        }
+    }
+}

--- a/src/haiku.rs
+++ b/src/haiku.rs
@@ -26,3 +26,13 @@ impl HaikuHandle {
         }
     }
 }
+
+impl From<new::HaikuWindowHandle> for HaikuHandle {
+    fn from(handle: new::HaikuWindowHandle) -> Self {
+        Self {
+            b_window: handle.b_window,
+            b_direct_window: handle.b_direct_window,
+            ..Self::empty()
+        }
+    }
+}

--- a/src/redox.rs
+++ b/src/redox.rs
@@ -23,3 +23,12 @@ impl OrbitalHandle {
         }
     }
 }
+
+impl From<new::OrbitalWindowHandle> for OrbitalHandle {
+    fn from(handle: new::OrbitalWindowHandle) -> Self {
+        Self {
+            window: handle.window,
+            ..Self::empty()
+        }
+    }
+}

--- a/src/uikit.rs
+++ b/src/uikit.rs
@@ -29,3 +29,14 @@ impl UiKitHandle {
         }
     }
 }
+
+impl From<new::UiKitWindowHandle> for UiKitHandle {
+    fn from(handle: new::UiKitWindowHandle) -> Self {
+        Self {
+            ui_window: handle.ui_window,
+            ui_view: handle.ui_view,
+            ui_view_controller: handle.ui_view_controller,
+            ..Self::empty()
+        }
+    }
+}

--- a/src/unix.rs
+++ b/src/unix.rs
@@ -86,3 +86,35 @@ impl WaylandHandle {
         }
     }
 }
+
+impl From<(new::XlibWindowHandle, new::XlibDisplayHandle)> for XlibHandle {
+    fn from(handle: (new::XlibWindowHandle, new::XlibDisplayHandle)) -> Self {
+        Self {
+            window: handle.0.window,
+            display: handle.1.display,
+            visual_id: handle.0.visual_id,
+            ..Self::empty()
+        }
+    }
+}
+
+impl From<(new::XcbWindowHandle, new::XcbDisplayHandle)> for XcbHandle {
+    fn from(handle: (new::XcbWindowHandle, new::XcbDisplayHandle)) -> Self {
+        Self {
+            window: handle.0.window,
+            connection: handle.1.connection,
+            visual_id: handle.0.visual_id,
+            ..Self::empty()
+        }
+    }
+}
+
+impl From<(new::WaylandWindowHandle, new::WaylandDisplayHandle)> for WaylandHandle {
+    fn from(handle: (new::WaylandWindowHandle, new::WaylandDisplayHandle)) -> Self {
+        Self {
+            surface: handle.0.surface,
+            display: handle.1.display,
+            ..Self::empty()
+        }
+    }
+}

--- a/src/web.rs
+++ b/src/web.rs
@@ -25,3 +25,12 @@ impl WebHandle {
         Self { id: 0 }
     }
 }
+
+impl From<new::WebWindowHandle> for WebHandle {
+    fn from(handle: new::WebWindowHandle) -> Self {
+        Self {
+            id: handle.id,
+            ..Self::empty()
+        }
+    }
+}

--- a/src/windows.rs
+++ b/src/windows.rs
@@ -27,6 +27,16 @@ impl Win32Handle {
     }
 }
 
+impl From<new::Win32WindowHandle> for Win32Handle {
+    fn from(handle: new::Win32WindowHandle) -> Self {
+        Self {
+            hwnd: handle.hwnd,
+            hinstance: handle.hinstance,
+            ..Self::empty()
+        }
+    }
+}
+
 /// Raw window handle for WinRT.
 ///
 /// ## Construction
@@ -46,6 +56,15 @@ impl WinRtHandle {
     pub fn empty() -> Self {
         Self {
             core_window: ptr::null_mut(),
+        }
+    }
+}
+
+impl From<new::WinRtWindowHandle> for WinRtHandle {
+    fn from(handle: new::WinRtWindowHandle) -> Self {
+        Self {
+            core_window: handle.core_window,
+            ..Self::empty()
         }
     }
 }


### PR DESCRIPTION
Similar approach as in https://github.com/rust-windowing/raw-window-handle/pull/74

Will follow up with a changelog entry to `master` afterwards.

Fixes `winit` issue https://github.com/rust-windowing/winit/issues/2415

CC @rib @maroider