### PR TITLE
Make `0.4 -> 0.5` not a breaking change by adding deprecated items

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.5.1 (2022-08-10)
+
+* Make upgrading `0.4 -> 0.5.1` not a breaking change by adding deprecated fields and type aliases.
+
 ## 0.5.0 (2022-07-14)
 
 * **Breaking:** The `RawWindowHandle` variants were split into `RawDisplayHandle` and `RawWindowHandle`.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "raw-window-handle"
-version = "0.5.0"
+version = "0.5.1"
 authors = ["Osspial <osspial@gmail.com>"]
 edition = "2018"
 description = "Interoperability library for Rust Windowing applications."

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -43,6 +43,29 @@ pub use unix::{
 pub use web::{WebDisplayHandle, WebWindowHandle};
 pub use windows::{Win32WindowHandle, WinRtWindowHandle, WindowsDisplayHandle};
 
+#[deprecated = "renamed to `AndroidNdkWindowHandle`"]
+pub type AndroidNdkHandle = AndroidNdkWindowHandle;
+#[deprecated = "renamed to `AppKitWindowHandle`"]
+pub type AppKitHandle = AppKitWindowHandle;
+#[deprecated = "renamed to `HaikuWindowHandle`"]
+pub type HaikuHandle = HaikuWindowHandle;
+#[deprecated = "renamed to `OrbitalWindowHandle`"]
+pub type OrbitalHandle = OrbitalWindowHandle;
+#[deprecated = "renamed to `UiKitWindowHandle`"]
+pub type UiKitHandle = UiKitWindowHandle;
+#[deprecated = "renamed to `XlibWindowHandle`"]
+pub type XlibHandle = XlibWindowHandle;
+#[deprecated = "renamed to `XcbWindowHandle`"]
+pub type XcbHandle = XcbWindowHandle;
+#[deprecated = "renamed to `WaylandWindowHandle`"]
+pub type WaylandHandle = WaylandWindowHandle;
+#[deprecated = "renamed to `WebWindowHandle`"]
+pub type WebHandle = WebWindowHandle;
+#[deprecated = "renamed to `Win32WindowHandle`"]
+pub type Win32Handle = Win32WindowHandle;
+#[deprecated = "renamed to `WinRtWindowHandle`"]
+pub type WinRtHandle = WinRtWindowHandle;
+
 /// Window that wraps around a raw window handle.
 ///
 /// # Safety

--- a/src/unix.rs
+++ b/src/unix.rs
@@ -38,6 +38,8 @@ pub struct XlibDisplayHandle {
 pub struct XlibWindowHandle {
     /// An Xlib `Window`.
     pub window: c_ulong,
+    #[deprecated = "use the `RawDisplayHandle` trait instead"]
+    pub display: *mut c_void,
     /// An Xlib visual ID, or 0 if unknown.
     pub visual_id: c_ulong,
 }
@@ -77,6 +79,8 @@ pub struct XcbDisplayHandle {
 pub struct XcbWindowHandle {
     /// An X11 `xcb_window_t`.
     pub window: u32, // Based on xproto.h
+    #[deprecated = "use the `RawDisplayHandle` trait instead"]
+    pub connection: *mut c_void,
     /// An X11 `xcb_visualid_t`, or 0 if unknown.
     pub visual_id: u32,
 }
@@ -109,6 +113,8 @@ pub struct WaylandDisplayHandle {
 pub struct WaylandWindowHandle {
     /// A pointer to a `wl_surface`.
     pub surface: *mut c_void,
+    #[deprecated = "use the `RawDisplayHandle` trait instead"]
+    pub display: *mut c_void,
 }
 
 /// Raw display handle for the Linux Kernel Mode Set/Direct Rendering Manager.


### PR DESCRIPTION
Solves https://github.com/rust-windowing/winit/issues/2415.

After this, we can then release `v0.4.4` as just a re-export of `v0.5.1`.

Of course we will have to remove these _at some point_, but at least it can wait until the next major release, at which point we may be ready to declare a `v1.0` and won't have to deal with breaking changes any more.

CC @rib @maroider @kchibisov