### PR TITLE
Specify MSRV

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,7 +31,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        rust_version: [stable, nightly]
+        rust_version: ["1.56", stable, nightly]
 
     steps:
       - uses: actions/checkout@v2

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.5.1 (2022-08-11)
+
+* Add the `rust-version` field.
+
 ## 0.5.0 (2022-07-14)
 
 * **Breaking:** The `RawWindowHandle` variants were split into `RawDisplayHandle` and `RawWindowHandle`.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,13 +2,14 @@
 name = "raw-window-handle"
 version = "0.5.0"
 authors = ["Osspial <osspial@gmail.com>"]
-edition = "2018"
+edition = "2021"
 description = "Interoperability library for Rust Windowing applications."
 license = "MIT OR Apache-2.0 OR Zlib"
 repository = "https://github.com/rust-windowing/raw-window-handle"
 keywords = ["windowing"]
 readme = "README.md"
 documentation = "https://docs.rs/raw-window-handle"
+rust-version = "1.56"
 
 [features]
 alloc = []

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "raw-window-handle"
-version = "0.5.0"
+version = "0.5.1"
 authors = ["Osspial <osspial@gmail.com>"]
 edition = "2021"
 description = "Interoperability library for Rust Windowing applications."


### PR DESCRIPTION
Note that the intention here is that bumping MSRV is _not_ a breaking change! An example:
- We release `v0.5.1` with the `rust-version` field specified.
- Later on, we change something such that a newer Rust version is required; we bump `rust-version`, and release `v0.5.2`
- Users using Rust 1.56 will automatically choose `v0.5.1`

EDIT: Forget that.