### PR TITLE
Add an invalid raw handle

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -97,6 +97,8 @@ unsafe impl<T: HasRawWindowHandle + ?Sized> HasRawWindowHandle for alloc::sync::
 #[non_exhaustive]
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub enum RawWindowHandle {
+    /// Not a valid raw handle
+    Invalid,
     /// A raw window handle for UIKit (Apple's non-macOS windowing library).
     ///
     /// ## Availability Hints
@@ -232,6 +234,8 @@ unsafe impl<T: HasRawDisplayHandle + ?Sized> HasRawDisplayHandle for alloc::sync
 #[non_exhaustive]
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub enum RawDisplayHandle {
+    /// Not a valid raw handle
+    Invalid,
     /// A raw display handle for UIKit (Apple's non-macOS windowing library).
     ///
     /// ## Availability Hints


### PR DESCRIPTION
When we want to return an empty or invalid handle, it is possible to create an empty handle for an arbitrary platform, but if there is a dedicated enum value for it, then we don't have to pick an arbitrary platform.

The usecase here is to implement HasRawWindowHandle for a `Window` struct that can be backed by any backed decided at runtime (example winit, or no backend at all). And the question is what handle to return when we don't have an handle. An `Invalid` one seems a better choice than `Haiku(HaikuDisplayHandle::empty())` (just an arbitrary random pick)

What do you think?