### PR TITLE
Remove `cty` dependency

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,7 +31,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        rust_version: ["1.56", stable, nightly]
+        rust_version: ["1.64", stable, nightly]
 
     steps:
       - uses: actions/checkout@v2

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Changelog
 
+* The `rust-version` was bumped to `1.64`
+
 ## 0.5.1 (2022-08-11)
 
 * Add the `rust-version` field.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,13 +9,10 @@ repository = "https://github.com/rust-windowing/raw-window-handle"
 keywords = ["windowing"]
 readme = "README.md"
 documentation = "https://docs.rs/raw-window-handle"
-rust-version = "1.56"
+rust-version = "1.64"
 
 [features]
 alloc = []
-
-[dependencies]
-cty = "0.2"
 
 [package.metadata.docs.rs]
 all-features = true

--- a/src/unix.rs
+++ b/src/unix.rs
@@ -1,7 +1,5 @@
-use core::ffi::c_void;
+use core::ffi::{c_int, c_ulong, c_void};
 use core::ptr;
-
-use cty::{c_int, c_ulong};
 
 /// Raw display handle for Xlib.
 ///


### PR DESCRIPTION
This bumps MSRV to 1.64 along the way.

Fixes #103.

--

It seems that `wgpu`(already 1.64) and friends are moving towards the `1.64`. In general rust considers MSRV bump as not breaking for 'stable - 2' (including stable).

