### PR TITLE
Change the "Active" struct to be sound

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,6 +13,7 @@ rust-version = "1.64"
 
 [features]
 alloc = []
+std = ["alloc"]
 
 [package.metadata.docs.rs]
 all-features = true

--- a/src/borrowed.rs
+++ b/src/borrowed.rs
@@ -335,13 +335,13 @@ impl<'a> HasDisplayHandle for DisplayHandle<'a> {
 /// the handle.
 ///
 /// Note that this guarantee only applies to *pointers*, and not any window ID types in the handle.
-/// This includes Window IDs (XIDs) from X11, `HWND`s from Win32, and the window ID for web platforms.
-/// There is no way for Rust to enforce any kind of invariant on these types, since:
+/// This includes Window IDs (XIDs) from X11 and the window ID for web platforms. There is no way for
+/// Rust to enforce any kind of invariant on these types, since:
 ///
 /// - For all three listed platforms, it is possible for safe code in the same process to delete
 ///   the window.
-/// - For X11 and Win32, it is possible for code in a different process to delete the window.
-/// - For X11, it is possible for code on a different *machine* to delete the window.
+/// - For X11, it is possible for code in a different process to delete the window. In fact, it is 
+///   possible for code on a different *machine* to delete the window.
 ///
 /// It is *also* possible for the window to be replaced with another, valid-but-different window. User
 /// code should be aware of this possibility, and should be ready to soundly handle the possible error
@@ -388,33 +388,12 @@ impl<H: HasWindowHandle + ?Sized> HasWindowHandle for alloc::sync::Arc<H> {
     }
 }
 
-/// The error type returned when a handle cannot be obtained.
-#[derive(Debug)]
-#[non_exhaustive]
-pub enum HandleError {
-    /// The handle is not currently active.
-    ///
-    /// See documentation on [`Active`] for more information.
-    Inactive,
-}
-
-impl fmt::Display for HandleError {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        match self {
-            Self::Inactive => write!(f, "the handle is not currently active"),
-        }
-    }
-}
-
-#[cfg(feature = "std")]
-impl std::error::Error for HandleError {}
-
 /// The handle to a window.
 ///
 /// This is the primary return type of the [`HasWindowHandle`] trait. All *pointers* within this type
 /// are guaranteed to be valid and not dangling for the lifetime of the handle. This excludes window IDs
-/// like XIDs, `HWND`s, and the window ID for web platforms. See the documentation on the
-/// [`HasWindowHandle`] trait for more information about these safety requirements.
+/// like XIDs and the window ID for web platforms. See the documentation on the [`HasWindowHandle`] 
+/// trait for more information about these safety requirements.
 ///
 /// This handle is guaranteed to be safe and valid. Get the underlying raw window handle with the
 /// [`HasRawWindowHandle`] trait.
@@ -473,6 +452,27 @@ impl HasWindowHandle for WindowHandle<'_> {
         Ok(self.clone())
     }
 }
+
+/// The error type returned when a handle cannot be obtained.
+#[derive(Debug)]
+#[non_exhaustive]
+pub enum HandleError {
+    /// The handle is not currently active.
+    ///
+    /// See documentation on [`Active`] for more information.
+    Inactive,
+}
+
+impl fmt::Display for HandleError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Inactive => write!(f, "the handle is not currently active"),
+        }
+    }
+}
+
+#[cfg(feature = "std")]
+impl std::error::Error for HandleError {}
 
 /// ```compile_fail
 /// use raw_window_handle::{Active, DisplayHandle, WindowHandle};

--- a/src/borrowed.rs
+++ b/src/borrowed.rs
@@ -323,7 +323,7 @@ fn _not_send_or_sync() {}
 #[cfg_attr(docsrs, doc(cfg(not(target_os = "android"))))]
 mod imp {
     //! We don't need to refcount the handles, so we can just use no-ops.
-    
+
     use core::cell::UnsafeCell;
     use core::marker::PhantomData;
 

--- a/src/borrowed.rs
+++ b/src/borrowed.rs
@@ -44,11 +44,7 @@ impl Active {
     /// Set the application to be inactive.
     ///
     /// This function may block until there are no more active handles.
-    ///
-    /// # Safety
-    ///
-    /// The application must actually be inactive.
-    pub unsafe fn set_inactive(&self) {
+    pub fn set_inactive(&self) {
         self.0.set_inactive()
     }
 
@@ -346,7 +342,7 @@ mod imp {
 
         pub(super) unsafe fn set_active(&self) {}
 
-        pub(super) unsafe fn set_inactive(&self) {}
+        pub(super) fn set_inactive(&self) {}
     }
 
     impl ActiveHandle<'_> {
@@ -431,7 +427,7 @@ mod imp {
             *self.active.write().unwrap() = true;
         }
 
-        pub(super) unsafe fn set_inactive(&self) {
+        pub(super) fn set_inactive(&self) {
             *self.active.write().unwrap() = false;
         }
     }

--- a/src/borrowed.rs
+++ b/src/borrowed.rs
@@ -2,6 +2,9 @@
 //!
 //! These should be 100% safe to pass around and use, no possibility of dangling or invalidity.
 
+#[cfg(all(not(feature = "std"), target_os = "android"))]
+compile_error!("Using borrowed handles on Android requires the `std` feature to be enabled.");
+
 use core::fmt;
 use core::hash::{Hash, Hasher};
 use core::marker::PhantomData;
@@ -434,7 +437,6 @@ mod imp {
 mod imp {
     //! We need to refcount the handles, so we use an `RwLock` to do so.
 
-    extern crate std;
     use std::sync::{RwLock, RwLockReadGuard};
 
     pub(super) struct Active {

--- a/src/borrowed.rs
+++ b/src/borrowed.rs
@@ -201,7 +201,7 @@ impl ActiveHandle<'_> {
 /// return an error if the application is inactive.
 ///
 /// Implementors of this trait will be windowing systems, like [`winit`] and [`sdl2`]. These windowing
-/// systems should implement this tait on types that already implement [`HasRawDisplayHandle`]. It
+/// systems should implement this trait on types that already implement [`HasRawDisplayHandle`]. It
 /// should be implemented by tying the lifetime of the [`DisplayHandle`] to the lifetime of the
 /// display object.
 ///
@@ -317,7 +317,7 @@ impl<'a> HasDisplayHandle for DisplayHandle<'a> {
 /// return an error if the application is inactive.
 ///
 /// Implementors of this trait will be windowing systems, like [`winit`] and [`sdl2`]. These windowing
-/// systems should implement this tait on types that already implement [`HasRawWindowHandle`]. First,
+/// systems should implement this trait on types that already implement [`HasRawWindowHandle`]. First,
 /// it should be made sure that the display type contains a unique [`Active`] ref-counted handle.
 /// To create a [`WindowHandle`], the [`Active`] should be used to create an [`ActiveHandle`] that is
 /// then used to create a [`WindowHandle`]. Finally, the raw window handle should be retrieved from

--- a/src/borrowed.rs
+++ b/src/borrowed.rs
@@ -220,6 +220,10 @@ impl ActiveHandle<'_> {
 /// constructors of [`DisplayHandle`]. This is because the `HasDisplayHandle` trait is safe to implement.
 ///
 /// [`HasRawDisplayHandle`]: crate::HasRawDisplayHandle
+/// [`winit`]: https://crates.io/crates/winit
+/// [`sdl2`]: https://crates.io/crates/sdl2
+/// [`wgpu`]: https://crates.io/crates/wgpu
+/// [`glutin`]: https://crates.io/crates/glutin
 pub trait HasDisplayHandle {
     /// Get a handle to the display controller of the windowing system.
     fn display_handle(&self) -> Result<DisplayHandle<'_>, HandleError>;
@@ -347,6 +351,11 @@ impl<'a> HasDisplayHandle for DisplayHandle<'a> {
 ///
 /// Note that these requirements are not enforced on `HasWindowHandle`, rather, they are enforced on the
 /// constructors of [`WindowHandle`]. This is because the `HasWindowHandle` trait is safe to implement.
+///
+/// [`winit`]: https://crates.io/crates/winit
+/// [`sdl2`]: https://crates.io/crates/sdl2
+/// [`wgpu`]: https://crates.io/crates/wgpu
+/// [`glutin`]: https://crates.io/crates/glutin
 pub trait HasWindowHandle {
     /// Get a handle to the window.
     fn window_handle(&self) -> Result<WindowHandle<'_>, HandleError>;

--- a/src/borrowed.rs
+++ b/src/borrowed.rs
@@ -323,14 +323,15 @@ fn _not_send_or_sync() {}
 #[cfg_attr(docsrs, doc(cfg(not(target_os = "android"))))]
 mod imp {
     //! We don't need to refcount the handles, so we can just use no-ops.
-
+    
+    use core::cell::UnsafeCell;
     use core::marker::PhantomData;
 
     pub(super) struct Active;
 
     #[derive(Clone)]
     pub(super) struct ActiveHandle<'a> {
-        _marker: PhantomData<&'a ()>,
+        _marker: PhantomData<&'a UnsafeCell<()>>,
     }
 
     impl Active {
@@ -353,6 +354,12 @@ mod imp {
             Self {
                 _marker: PhantomData,
             }
+        }
+    }
+
+    impl Drop for ActiveHandle<'_> {
+        fn drop(&mut self) {
+            // Done for consistency with the refcounted version.
         }
     }
 

--- a/src/borrowed.rs
+++ b/src/borrowed.rs
@@ -340,7 +340,7 @@ impl<'a> HasDisplayHandle for DisplayHandle<'a> {
 ///
 /// - For all three listed platforms, it is possible for safe code in the same process to delete
 ///   the window.
-/// - For X11, it is possible for code in a different process to delete the window. In fact, it is 
+/// - For X11, it is possible for code in a different process to delete the window. In fact, it is
 ///   possible for code on a different *machine* to delete the window.
 ///
 /// It is *also* possible for the window to be replaced with another, valid-but-different window. User
@@ -392,7 +392,7 @@ impl<H: HasWindowHandle + ?Sized> HasWindowHandle for alloc::sync::Arc<H> {
 ///
 /// This is the primary return type of the [`HasWindowHandle`] trait. All *pointers* within this type
 /// are guaranteed to be valid and not dangling for the lifetime of the handle. This excludes window IDs
-/// like XIDs and the window ID for web platforms. See the documentation on the [`HasWindowHandle`] 
+/// like XIDs and the window ID for web platforms. See the documentation on the [`HasWindowHandle`]
 /// trait for more information about these safety requirements.
 ///
 /// This handle is guaranteed to be safe and valid. Get the underlying raw window handle with the

--- a/src/borrowed.rs
+++ b/src/borrowed.rs
@@ -91,73 +91,30 @@ pub trait HasDisplayHandle {
     fn display_handle(&self) -> DisplayHandle<'_>;
 }
 
-impl<T: HasDisplayHandle + ?Sized> HasDisplayHandle for &T {
-    fn active(&self) -> Option<Active<'_>> {
-        (**self).active()
-    }
-
-    fn display_handle<'this, 'active>(
-        &'this self,
-        active: &'active Active<'_>,
-    ) -> DisplayHandle<'this>
-    where
-        'active: 'this,
-    {
-        (**self).display_handle(active)
+impl<H: HasDisplayHandle + ?Sized> HasDisplayHandle for &H {
+    fn display_handle(&self) -> DisplayHandle<'_> {
+        (**self).display_handle()
     }
 }
 
 #[cfg(feature = "alloc")]
-#[cfg_attr(docsrs, doc(cfg(feature = "alloc")))]
-impl<T: HasDisplayHandle + ?Sized> HasDisplayHandle for alloc::boxed::Box<T> {
-    fn active(&self) -> Option<Active<'_>> {
-        (**self).active()
-    }
-
-    fn display_handle<'this, 'active>(
-        &'this self,
-        active: &'active Active<'_>,
-    ) -> DisplayHandle<'this>
-    where
-        'active: 'this,
-    {
-        (**self).display_handle(active)
+impl<H: HasDisplayHandle + ?Sized> HasDisplayHandle for alloc::boxed::Box<H> {
+    fn display_handle(&self) -> DisplayHandle<'_> {
+        (**self).display_handle()
     }
 }
 
 #[cfg(feature = "alloc")]
-#[cfg_attr(docsrs, doc(cfg(feature = "alloc")))]
-impl<T: HasDisplayHandle + ?Sized> HasDisplayHandle for alloc::rc::Rc<T> {
-    fn active(&self) -> Option<Active<'_>> {
-        (**self).active()
-    }
-
-    fn display_handle<'this, 'active>(
-        &'this self,
-        active: &'active Active<'_>,
-    ) -> DisplayHandle<'this>
-    where
-        'active: 'this,
-    {
-        (**self).display_handle(active)
+impl<H: HasDisplayHandle + ?Sized> HasDisplayHandle for alloc::rc::Rc<H> {
+    fn display_handle(&self) -> DisplayHandle<'_> {
+        (**self).display_handle()
     }
 }
 
 #[cfg(feature = "alloc")]
-#[cfg_attr(docsrs, doc(cfg(feature = "alloc")))]
-impl<T: HasDisplayHandle + ?Sized> HasDisplayHandle for alloc::sync::Arc<T> {
-    fn active(&self) -> Option<Active<'_>> {
-        (**self).active()
-    }
-
-    fn display_handle<'this, 'active>(
-        &'this self,
-        active: &'active Active<'_>,
-    ) -> DisplayHandle<'this>
-    where
-        'active: 'this,
-    {
-        (**self).display_handle(active)
+impl<H: HasDisplayHandle + ?Sized> HasDisplayHandle for alloc::sync::Arc<H> {
+    fn display_handle(&self) -> DisplayHandle<'_> {
+        (**self).display_handle()
     }
 }
 
@@ -239,67 +196,54 @@ impl<'a> HasDisplayHandle for DisplayHandle<'a> {
 /// constructors of [`WindowHandle`]. This is because the `HasWindowHandle` trait is safe to implement.
 pub trait HasWindowHandle {
     /// Get a handle to the window.
-    fn window_handle<'this, 'active>(
-        &'this self,
-        active: ActiveHandle<'active>,
-    ) -> WindowHandle<'this>
-    where
-        'active: 'this;
+    fn window_handle(&self) -> Result<WindowHandle<'_>, WindowHandleError>;
 }
 
-impl<T: HasWindowHandle + ?Sized> HasWindowHandle for &T {
-    fn window_handle<'this, 'active>(
-        &'this self,
-        active: &'active Active<'_>,
-    ) -> WindowHandle<'this>
-    where
-        'active: 'this,
-    {
-        (**self).window_handle(active)
+impl<H: HasWindowHandle + ?Sized> HasWindowHandle for &H {
+    fn window_handle(&self) -> Result<WindowHandle<'_>, WindowHandleError> {
+        (**self).window_handle()
     }
 }
 
 #[cfg(feature = "alloc")]
-#[cfg_attr(docsrs, doc(cfg(feature = "alloc")))]
-impl<T: HasWindowHandle + ?Sized> HasWindowHandle for alloc::boxed::Box<T> {
-    fn window_handle<'this, 'active>(
-        &'this self,
-        active: &'active Active<'_>,
-    ) -> WindowHandle<'this>
-    where
-        'active: 'this,
-    {
-        (**self).window_handle(active)
+impl<H: HasWindowHandle + ?Sized> HasWindowHandle for alloc::boxed::Box<H> {
+    fn window_handle(&self) -> Result<WindowHandle<'_>, WindowHandleError> {
+        (**self).window_handle()
     }
 }
 
 #[cfg(feature = "alloc")]
-#[cfg_attr(docsrs, doc(cfg(feature = "alloc")))]
-impl<T: HasWindowHandle + ?Sized> HasWindowHandle for alloc::rc::Rc<T> {
-    fn window_handle<'this, 'active>(
-        &'this self,
-        active: &'active Active<'_>,
-    ) -> WindowHandle<'this>
-    where
-        'active: 'this,
-    {
-        (**self).window_handle(active)
+impl<H: HasWindowHandle + ?Sized> HasWindowHandle for alloc::rc::Rc<H> {
+    fn window_handle(&self) -> Result<WindowHandle<'_>, WindowHandleError> {
+        (**self).window_handle()
     }
 }
 
 #[cfg(feature = "alloc")]
-#[cfg_attr(docsrs, doc(cfg(feature = "alloc")))]
-impl<T: HasWindowHandle + ?Sized> HasWindowHandle for alloc::sync::Arc<T> {
-    fn window_handle<'this, 'active>(
-        &'this self,
-        active: &'active Active<'_>,
-    ) -> WindowHandle<'this>
-    where
-        'active: 'this,
-    {
-        (**self).window_handle(active)
+impl<H: HasWindowHandle + ?Sized> HasWindowHandle for alloc::sync::Arc<H> {
+    fn window_handle(&self) -> Result<WindowHandle<'_>, WindowHandleError> {
+        (**self).window_handle()
     }
 }
+
+/// The error type returned when a window handle cannot be obtained.
+#[derive(Debug)]
+#[non_exhaustive]
+pub enum WindowHandleError {
+    /// The window is not currently active.
+    Inactive,
+}
+
+impl fmt::Display for WindowHandleError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Inactive => write!(f, "the window is not currently active"),
+        }
+    }
+}
+
+#[cfg(feature = "std")]
+impl std::error::Error for WindowHandleError {}
 
 /// The handle to a window.
 ///
@@ -358,19 +302,9 @@ unsafe impl HasRawWindowHandle for WindowHandle<'_> {
     }
 }
 
-impl<'a> HasWindowHandle for WindowHandle<'a> {
-    fn window_handle<'this, 'active>(
-        &'this self,
-        active: ActiveHandle<'active>,
-    ) -> WindowHandle<'this>
-    where
-        'active: 'this,
-    {
-        WindowHandle {
-            raw: self.raw,
-            _active: active,
-            _marker: PhantomData,
-        }
+impl HasWindowHandle for WindowHandle<'_> {
+    fn window_handle(&self) -> Result<Self, WindowHandleError> {
+        Ok(self.clone())
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -45,6 +45,7 @@ pub use android::{AndroidDisplayHandle, AndroidNdkWindowHandle};
 pub use appkit::{AppKitDisplayHandle, AppKitWindowHandle};
 pub use borrowed::{
     Active, ActiveHandle, DisplayHandle, HasDisplayHandle, HasWindowHandle, WindowHandle,
+    WindowHandleError,
 };
 pub use haiku::{HaikuDisplayHandle, HaikuWindowHandle};
 pub use redox::{OrbitalDisplayHandle, OrbitalWindowHandle};

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -28,6 +28,9 @@
 #[cfg(feature = "alloc")]
 extern crate alloc;
 
+#[cfg(feature = "std")]
+extern crate std;
+
 mod android;
 mod appkit;
 mod borrowed;
@@ -40,7 +43,9 @@ mod windows;
 
 pub use android::{AndroidDisplayHandle, AndroidNdkWindowHandle};
 pub use appkit::{AppKitDisplayHandle, AppKitWindowHandle};
-pub use borrowed::{Active, DisplayHandle, HasDisplayHandle, HasWindowHandle, WindowHandle};
+pub use borrowed::{
+    Active, ActiveHandle, DisplayHandle, HasDisplayHandle, HasWindowHandle, WindowHandle,
+};
 pub use haiku::{HaikuDisplayHandle, HaikuWindowHandle};
 pub use redox::{OrbitalDisplayHandle, OrbitalWindowHandle};
 pub use uikit::{UiKitDisplayHandle, UiKitWindowHandle};

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -44,8 +44,8 @@ mod windows;
 pub use android::{AndroidDisplayHandle, AndroidNdkWindowHandle};
 pub use appkit::{AppKitDisplayHandle, AppKitWindowHandle};
 pub use borrowed::{
-    Active, ActiveHandle, DisplayHandle, HasDisplayHandle, HasWindowHandle, WindowHandle,
-    WindowHandleError,
+    Active, ActiveHandle, DisplayHandle, HandleError, HasDisplayHandle, HasWindowHandle,
+    WindowHandle,
 };
 pub use haiku::{HaikuDisplayHandle, HaikuWindowHandle};
 pub use redox::{OrbitalDisplayHandle, OrbitalWindowHandle};


### PR DESCRIPTION
The previous implementation is unsound in several cases. This PR ensures that window handles don't outlive the application.

Draft until I can verify that it actually works. Supersedes #114 