### PR TITLE
Restrict compilation of borrowed handles on Android

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,8 +51,8 @@ jobs:
       - name: Run tests with std
         run: cargo test --verbose --features std
 
-      - name: Run tests on Android
-        run: cargo test --verbose --target x86_64-linux-android
+      - name: Check on Android
+        run: cargo check --verbose --target x86_64-linux-android
 
-      - name: Run tests on Android with std
-        run: cargo test --verbose --target x86_64-linux-android --features std
+      - name: Check on Android with std
+        run: cargo check --verbose --target x86_64-linux-android --features std

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,8 +26,8 @@ jobs:
 
   tests:
     name: Tests
-    # Note: `raw-window-handle` doesn't have any `#[cfg(...)]` guards, so
-    # we don't bother testing on other platforms
+    # `raw-window-handle` only has `cfg` guards for Android, so we just run Ubuntu
+    # and manually test Android
     runs-on: ubuntu-latest
     strategy:
       matrix:
@@ -40,8 +40,19 @@ jobs:
         with:
           rust-version: ${{ matrix.rust_version }}
 
+      - run: rustup target add x86_64-linux-android
+
       - name: Check documentation
         run: cargo doc --no-deps --document-private-items
 
       - name: Run tests
         run: cargo test --verbose
+
+      - name: Run tests with std
+        run: cargo test --verbose --features std
+
+      - name: Run tests on Android
+        run: cargo test --verbose --target x86_64-linux-android
+
+      - name: Run tests on Android with std
+        run: cargo test --verbose --target x86_64-linux-android --features std

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -33,6 +33,8 @@ extern crate std;
 
 mod android;
 mod appkit;
+#[cfg(any(feature = "std", not(target_os = "android")))]
+#[cfg_attr(docsrs, doc(cfg(any(feature = "std", not(target_os = "android")))))]
 mod borrowed;
 mod haiku;
 mod redox;
@@ -43,6 +45,7 @@ mod windows;
 
 pub use android::{AndroidDisplayHandle, AndroidNdkWindowHandle};
 pub use appkit::{AppKitDisplayHandle, AppKitWindowHandle};
+#[cfg(any(feature = "std", not(target_os = "android")))]
 pub use borrowed::{
     Active, ActiveHandle, DisplayHandle, HandleError, HasDisplayHandle, HasWindowHandle,
     WindowHandle,


### PR DESCRIPTION
Guards borrowed handles behind either `std` or not being on Android. Should prevent this from being a breaking change.

Another possible way around this would be to add a `borrowed` feature.