### PR TITLE
Remove window handles from Apple handles

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 * **Breaking:** `HasRaw(Display/Window)Handle::raw_(display/window)_handle` returns a result indicating if fetching the window handle failed (#122).
 * **Breaking:** Remove the `Active/ActiveHandle` types from the public API (#126).
+* **Breaking:** Remove `AppKitWindowHandle::ns_window` and `UiKitWindowHandle::ui_window` since they can be retrived from the view (#129).
 
 ## 0.5.2 (2023-03-31)
 

--- a/src/appkit.rs
+++ b/src/appkit.rs
@@ -30,17 +30,13 @@ impl AppKitDisplayHandle {
 #[non_exhaustive]
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub struct AppKitWindowHandle {
-    /// A pointer to an `NSWindow` object.
-    pub ns_window: *mut c_void,
     /// A pointer to an `NSView` object.
     pub ns_view: *mut c_void,
-    // TODO: WHAT ABOUT ns_window_controller and ns_view_controller?
 }
 
 impl AppKitWindowHandle {
     pub fn empty() -> Self {
         Self {
-            ns_window: ptr::null_mut(),
             ns_view: ptr::null_mut(),
         }
     }

--- a/src/uikit.rs
+++ b/src/uikit.rs
@@ -30,18 +30,15 @@ impl UiKitDisplayHandle {
 #[non_exhaustive]
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub struct UiKitWindowHandle {
-    /// A pointer to an `UIWindow` object.
-    pub ui_window: *mut c_void,
     /// A pointer to an `UIView` object.
     pub ui_view: *mut c_void,
-    /// A pointer to an `UIViewController` object.
+    /// A pointer to an `UIViewController` object, if the view has one.
     pub ui_view_controller: *mut c_void,
 }
 
 impl UiKitWindowHandle {
     pub fn empty() -> Self {
         Self {
-            ui_window: ptr::null_mut(),
             ui_view: ptr::null_mut(),
             ui_view_controller: ptr::null_mut(),
         }


### PR DESCRIPTION
The window can easily be fetched from the view, and having it leads to confusion over which place you should be e.g. taking the drawing dimensions (always the view).

Part of https://github.com/rust-windowing/raw-window-handle/issues/123