### PR TITLE
v0.6.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## Unreleased
+## 0.6.0 (2023-XX-XX)
 
 * **Breaking:** Raw pointer handles now use `NonNull` where appropriate, to avoid null pointer dereferences.
 * **Breaking:** Renamed `empty` methods to `new`, and take parameters in most of those, to better match normal Rust semantics.
@@ -8,6 +8,10 @@
 * **Breaking:** Remove the `Active/ActiveHandle` types from the public API (#126).
 * **Breaking:** Remove `AppKitWindowHandle::ns_window` and `UiKitWindowHandle::ui_window` since they can be retrieved from the view (#129).
 * **Breaking:** Remove `Copy` derive from `RawWindowHandle` and `WindowHandle` (#140).
+* Implement `PartialEq`, `Eq` and `Hash` for `WindowHandle` too. (#128)
+* Implement the relevant traits for `&mut T where T: <trait>`. (#130)
+* Add web handles for `wasm-bindgen` v0.2. They are locked behind the `wasm-bindgen-0-2` feature. (#134)
+* Deprecate the raw window/display handle traits. They will be removed at the next stable release. (#139)
 
 ## 0.5.2 (2023-03-31)
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "raw-window-handle"
-version = "0.5.2"
+version = "0.6.0"
 authors = ["Osspial <osspial@gmail.com>"]
 edition = "2021"
 description = "Interoperability library for Rust Windowing applications."


### PR DESCRIPTION
* **Breaking:** Raw pointer handles now use `NonNull` where appropriate, to avoid null pointer dereferences.
* **Breaking:** Renamed `empty` methods to `new`, and take parameters in most of those, to better match normal Rust semantics.
* **Breaking:** `HasRaw(Display/Window)Handle::raw_(display/window)_handle` returns a result indicating if fetching the window handle failed (#122).
* **Breaking:** Remove the `Active/ActiveHandle` types from the public API (#126).
* **Breaking:** Remove `AppKitWindowHandle::ns_window` and `UiKitWindowHandle::ui_window` since they can be retrieved from the view (#129).
* **Breaking:** Remove `Copy` derive from `RawWindowHandle` and `WindowHandle` (#140).
* Implement `PartialEq`, `Eq` and `Hash` for `WindowHandle` too. (#128)
* Implement the relevant traits for `&mut T where T: <trait>`. (#130)
* Add web handles for `wasm-bindgen` v0.2. They are locked behind the `wasm-bindgen-0-2` feature. (#134)
* Deprecate the raw window/display handle traits. They will be removed at the next stable release. (#139)