### PR TITLE
Implement traits for &mut T

### DIFF
--- a/src/borrowed.rs
+++ b/src/borrowed.rs
@@ -50,6 +50,12 @@ impl<H: HasDisplayHandle + ?Sized> HasDisplayHandle for &H {
     }
 }
 
+impl<H: HasDisplayHandle + ?Sized> HasDisplayHandle for &mut H {
+    fn display_handle(&self) -> Result<DisplayHandle<'_>, HandleError> {
+        (**self).display_handle()
+    }
+}
+
 #[cfg(feature = "alloc")]
 impl<H: HasDisplayHandle + ?Sized> HasDisplayHandle for alloc::boxed::Box<H> {
     fn display_handle(&self) -> Result<DisplayHandle<'_>, HandleError> {
@@ -162,6 +168,12 @@ pub trait HasWindowHandle {
 }
 
 impl<H: HasWindowHandle + ?Sized> HasWindowHandle for &H {
+    fn window_handle(&self) -> Result<WindowHandle<'_>, HandleError> {
+        (**self).window_handle()
+    }
+}
+
+impl<H: HasWindowHandle + ?Sized> HasWindowHandle for &mut H {
     fn window_handle(&self) -> Result<WindowHandle<'_>, HandleError> {
         (**self).window_handle()
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -79,6 +79,11 @@ unsafe impl<'a, T: HasRawWindowHandle + ?Sized> HasRawWindowHandle for &'a T {
         (*self).raw_window_handle()
     }
 }
+unsafe impl<'a, T: HasRawWindowHandle + ?Sized> HasRawWindowHandle for &'a mut T {
+    fn raw_window_handle(&self) -> Result<RawWindowHandle, HandleError> {
+        (**self).raw_window_handle()
+    }
+}
 #[cfg(feature = "alloc")]
 #[cfg_attr(docsrs, doc(cfg(feature = "alloc")))]
 unsafe impl<T: HasRawWindowHandle + ?Sized> HasRawWindowHandle for alloc::rc::Rc<T> {
@@ -217,6 +222,12 @@ pub unsafe trait HasRawDisplayHandle {
 unsafe impl<'a, T: HasRawDisplayHandle + ?Sized> HasRawDisplayHandle for &'a T {
     fn raw_display_handle(&self) -> Result<RawDisplayHandle, HandleError> {
         (*self).raw_display_handle()
+    }
+}
+
+unsafe impl<'a, T: HasRawDisplayHandle + ?Sized> HasRawDisplayHandle for &'a mut T {
+    fn raw_display_handle(&self) -> Result<RawDisplayHandle, HandleError> {
+        (**self).raw_display_handle()
     }
 }
 


### PR DESCRIPTION
As the traits are implemented for `&T` where `T` implements the traits, I'm not sure why they can't also be implemented for `&mut T`.