### PR TITLE
Make integer handles use non-zero types

### DIFF
--- a/src/unix.rs
+++ b/src/unix.rs
@@ -1,4 +1,5 @@
 use core::ffi::{c_int, c_ulong, c_void};
+use core::num::NonZeroU32;
 use core::ptr::NonNull;
 
 /// Raw display handle for Xlib.
@@ -114,9 +115,9 @@ impl XcbDisplayHandle {
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub struct XcbWindowHandle {
     /// An X11 `xcb_window_t`.
-    pub window: u32, // Based on xproto.h
-    /// An X11 `xcb_visualid_t`, or 0 if unknown.
-    pub visual_id: u32,
+    pub window: NonZeroU32, // Based on xproto.h
+    /// An X11 `xcb_visualid_t`.
+    pub visual_id: Option<NonZeroU32>,
 }
 
 impl XcbWindowHandle {
@@ -126,18 +127,19 @@ impl XcbWindowHandle {
     /// # Example
     ///
     /// ```
+    /// # use core::num::NonZeroU32;
     /// # use raw_window_handle::XcbWindowHandle;
     /// #
-    /// let window: u32;
-    /// # window = 0;
+    /// let window: NonZeroU32;
+    /// # window = NonZeroU32::new(1).unwrap();
     /// let mut handle = XcbWindowHandle::new(window);
     /// // Optionally set the visual ID.
-    /// handle.visual_id = 0;
+    /// handle.visual_id = None;
     /// ```
-    pub fn new(window: u32) -> Self {
+    pub fn new(window: NonZeroU32) -> Self {
         Self {
             window,
-            visual_id: 0,
+            visual_id: None,
         }
     }
 }

--- a/src/windows.rs
+++ b/src/windows.rs
@@ -1,4 +1,5 @@
 use core::ffi::c_void;
+use core::num::NonZeroIsize;
 use core::ptr::NonNull;
 
 /// Raw display handle for Windows.
@@ -28,9 +29,9 @@ impl WindowsDisplayHandle {
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub struct Win32WindowHandle {
     /// A Win32 `HWND` handle.
-    pub hwnd: isize,
+    pub hwnd: NonZeroIsize,
     /// The `GWLP_HINSTANCE` associated with this type's `HWND`.
-    pub hinstance: isize,
+    pub hinstance: Option<NonZeroIsize>,
 }
 
 impl Win32WindowHandle {
@@ -40,20 +41,24 @@ impl Win32WindowHandle {
     /// # Example
     ///
     /// ```
+    /// # use core::num::NonZeroIsize;
     /// # use raw_window_handle::Win32WindowHandle;
     /// # struct HWND(isize);
     /// #
     /// let window: HWND;
-    /// # window = HWND(0);
-    /// let mut handle = Win32WindowHandle::new(window.0);
+    /// # window = HWND(1);
+    /// let mut handle = Win32WindowHandle::new(NonZeroIsize::new(window.0).unwrap());
     /// // Optionally set the GWLP_HINSTANCE.
     /// # #[cfg(only_for_showcase)]
-    /// let hinstance = unsafe { GetWindowLongPtrW(window, GWLP_HINSTANCE) };
-    /// # let hinstance = 0;
+    /// let hinstance = NonZeroIsize::new(unsafe { GetWindowLongPtrW(window, GWLP_HINSTANCE) }).unwrap();
+    /// # let hinstance = None;
     /// handle.hinstance = hinstance;
     /// ```
-    pub fn new(hwnd: isize) -> Self {
-        Self { hwnd, hinstance: 0 }
+    pub fn new(hwnd: NonZeroIsize) -> Self {
+        Self {
+            hwnd,
+            hinstance: None,
+        }
     }
 }
 


### PR DESCRIPTION
In similar spirit as https://github.com/rust-windowing/raw-window-handle/pull/136.

I'm not sure myself that this is such a good idea, mainly because:
- The `c_int/c_long` types are not possible to convert to non-zero types in the same manner (leading to us only using the API in some places).
- Ensuring non-null pointers is _important_, since that causes unsoundness if used incorrectly, while a zero handle isn't that big of a problem, any operations you do on them will just error (just like any other invalid handle).

Other options would be to panic on `0` in the constructor (a weak check against invalid handles, assuming those are exceedingly rare), or we could document that it is a bug in the implementer (as opposed to the consumer) to provide zero handles where unexpected?