### PR TITLE
Make handles Send + Sync

### DIFF
--- a/src/android.rs
+++ b/src/android.rs
@@ -29,6 +29,10 @@ pub struct AndroidNdkWindowHandle {
     pub a_native_window: NonNull<c_void>,
 }
 
+// SAFETY: `ndk::native_window::NativeWindow` is `Send + Sync`.
+unsafe impl Send for AndroidNdkWindowHandle {}
+unsafe impl Sync for AndroidNdkWindowHandle {}
+
 impl AndroidNdkWindowHandle {
     /// Create a new handle to an `ANativeWindow`.
     ///

--- a/src/appkit.rs
+++ b/src/appkit.rs
@@ -22,12 +22,26 @@ impl AppKitDisplayHandle {
 }
 
 /// Raw window handle for AppKit.
+///
+/// Note that while this is `Send + Sync`, it is only usable from the main
+/// thread. Any usage of `NSView` outside the main thread may be undefined
+/// behaviour, unless explicitly documented otherwise.
+///
+/// You must check whether the thread is the main thread before accessing
+/// this, and if it is not, you should execute your code to access the view
+/// on the main thread instead using `libdispatch`.
 #[non_exhaustive]
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub struct AppKitWindowHandle {
     /// A pointer to an `NSView` object.
     pub ns_view: NonNull<c_void>,
 }
+
+// SAFETY: Only accessible from the main thread.
+//
+// Acts as-if the view is wrapped in `MainThreadBound<T>`.
+unsafe impl Send for AppKitWindowHandle {}
+unsafe impl Sync for AppKitWindowHandle {}
 
 impl AppKitWindowHandle {
     /// Create a new handle to a view.

--- a/src/borrowed.rs
+++ b/src/borrowed.rs
@@ -79,7 +79,7 @@ impl<H: HasDisplayHandle + ?Sized> HasDisplayHandle for alloc::sync::Arc<H> {
 #[derive(PartialEq, Eq, Hash, Copy, Clone)]
 pub struct DisplayHandle<'a> {
     raw: RawDisplayHandle,
-    _marker: PhantomData<&'a *const ()>,
+    _marker: PhantomData<&'a ()>,
 }
 
 impl fmt::Debug for DisplayHandle<'_> {
@@ -210,7 +210,7 @@ impl<H: HasWindowHandle + ?Sized> HasWindowHandle for alloc::sync::Arc<H> {
 #[derive(PartialEq, Eq, Hash, Copy, Clone)]
 pub struct WindowHandle<'a> {
     raw: RawWindowHandle,
-    _marker: PhantomData<&'a *const ()>,
+    _marker: PhantomData<&'a ()>,
 }
 
 impl fmt::Debug for WindowHandle<'_> {
@@ -280,11 +280,3 @@ impl HasWindowHandle for WindowHandle<'_> {
         Ok(*self)
     }
 }
-
-/// ```compile_fail
-/// use raw_window_handle::{DisplayHandle, WindowHandle};
-/// fn _assert<T: Send + Sync>() {}
-/// _assert::<DisplayHandle<'static>>();
-/// _assert::<WindowHandle<'static>>();
-/// ```
-fn _not_send_or_sync() {}

--- a/src/haiku.rs
+++ b/src/haiku.rs
@@ -31,6 +31,12 @@ pub struct HaikuWindowHandle {
     pub b_direct_window: Option<NonNull<c_void>>,
 }
 
+// SAFETY: `BWindow` and `BDirectWindow` are thread safe.
+//
+// TODO: Documentation for this.
+unsafe impl Send for HaikuWindowHandle {}
+unsafe impl Sync for HaikuWindowHandle {}
+
 impl HaikuWindowHandle {
     /// Create a new handle to a window.
     ///

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -420,3 +420,44 @@ from_impl!(
 );
 from_impl!(RawWindowHandle, AndroidNdk, AndroidNdkWindowHandle);
 from_impl!(RawWindowHandle, Haiku, HaikuWindowHandle);
+
+#[cfg(test)]
+mod tests {
+    use core::panic::{RefUnwindSafe, UnwindSafe};
+
+    use super::*;
+
+    #[test]
+    fn auto_traits() {
+        fn assert_send_sync<T: Send + Sync>() {}
+        fn assert_unwindsafe<T: UnwindSafe + RefUnwindSafe>() {}
+        fn assert_unpin<T: Unpin>() {}
+
+        assert_send_sync::<RawDisplayHandle>();
+        assert_send_sync::<DisplayHandle<'_>>();
+        assert_unwindsafe::<RawDisplayHandle>();
+        assert_unwindsafe::<DisplayHandle<'_>>();
+        assert_unpin::<RawDisplayHandle>();
+        assert_unpin::<DisplayHandle<'_>>();
+
+        assert_send_sync::<RawWindowHandle>();
+        assert_send_sync::<WindowHandle<'_>>();
+        assert_unwindsafe::<RawWindowHandle>();
+        assert_unwindsafe::<WindowHandle<'_>>();
+        assert_unpin::<RawWindowHandle>();
+        assert_unpin::<WindowHandle<'_>>();
+
+        assert_send_sync::<HandleError>();
+        assert_unwindsafe::<HandleError>();
+        assert_unpin::<HandleError>();
+    }
+
+    #[allow(deprecated, unused)]
+    fn assert_object_safe(
+        _: &dyn HasRawWindowHandle,
+        _: &dyn HasRawDisplayHandle,
+        _: &dyn HasWindowHandle,
+        _: &dyn HasDisplayHandle,
+    ) {
+    }
+}

--- a/src/redox.rs
+++ b/src/redox.rs
@@ -31,6 +31,13 @@ pub struct OrbitalWindowHandle {
     pub window: NonNull<c_void>,
 }
 
+// SAFETY: `orbclient`` windows are essentially just a file descriptor, and
+// are hence thread safe.
+//
+// TODO: Documentation for this.
+unsafe impl Send for OrbitalWindowHandle {}
+unsafe impl Sync for OrbitalWindowHandle {}
+
 impl OrbitalWindowHandle {
     /// Create a new handle to a window.
     ///

--- a/src/uikit.rs
+++ b/src/uikit.rs
@@ -22,6 +22,15 @@ impl UiKitDisplayHandle {
 }
 
 /// Raw window handle for UIKit.
+///
+/// Note that while this is `Send + Sync`, it is only usable from the main
+/// thread. Any usage of `UIView` and `UIViewController` outside the main
+/// thread may be undefined behaviour, unless explicitly documented
+/// otherwise.
+///
+/// You must check whether the thread is the main thread before accessing
+/// this, and if it is not, you should execute your code to access the view
+/// and view controller on the main thread instead using `libdispatch`.
 #[non_exhaustive]
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub struct UiKitWindowHandle {
@@ -30,6 +39,12 @@ pub struct UiKitWindowHandle {
     /// A pointer to an `UIViewController` object, if the view has one.
     pub ui_view_controller: Option<NonNull<c_void>>,
 }
+
+// SAFETY: Only accessible from the main thread.
+//
+// Acts as-if the view is wrapped in `MainThreadBound<T>`.
+unsafe impl Send for UiKitWindowHandle {}
+unsafe impl Sync for UiKitWindowHandle {}
 
 impl UiKitWindowHandle {
     /// Create a new handle to a view.

--- a/src/unix.rs
+++ b/src/unix.rs
@@ -20,6 +20,12 @@ pub struct XlibDisplayHandle {
     pub screen: c_int,
 }
 
+// SAFETY: Xlib `Display` is thread safe.
+//
+// TODO: Documentation for this?
+unsafe impl Send for XlibDisplayHandle {}
+unsafe impl Sync for XlibDisplayHandle {}
+
 impl XlibDisplayHandle {
     /// Create a new handle to a display.
     ///
@@ -94,6 +100,12 @@ pub struct XcbDisplayHandle {
     pub screen: c_int,
 }
 
+// SAFETY: `xcb_connection_t` is thread safe.
+//
+// TODO: Documentation for this?
+unsafe impl Send for XcbDisplayHandle {}
+unsafe impl Sync for XcbDisplayHandle {}
+
 impl XcbDisplayHandle {
     /// Create a new handle to a connection and screen.
     ///
@@ -158,6 +170,12 @@ pub struct WaylandDisplayHandle {
     pub display: NonNull<c_void>,
 }
 
+// SAFETY: `wl_display` is thread safe.
+//
+// TODO: Documentation for this?
+unsafe impl Send for WaylandDisplayHandle {}
+unsafe impl Sync for WaylandDisplayHandle {}
+
 impl WaylandDisplayHandle {
     /// Create a new display handle.
     ///
@@ -185,6 +203,12 @@ pub struct WaylandWindowHandle {
     /// A pointer to a `wl_surface`.
     pub surface: NonNull<c_void>,
 }
+
+// SAFETY: `wl_surface` is thread safe.
+//
+// TODO: Documentation for this?
+unsafe impl Send for WaylandWindowHandle {}
+unsafe impl Sync for WaylandWindowHandle {}
 
 impl WaylandWindowHandle {
     /// Create a new handle to a surface.
@@ -267,6 +291,12 @@ pub struct GbmDisplayHandle {
     pub gbm_device: NonNull<c_void>,
 }
 
+// SAFETY: GBM is thread safe.
+//
+// TODO: Documentation for this?
+unsafe impl Send for GbmDisplayHandle {}
+unsafe impl Sync for GbmDisplayHandle {}
+
 impl GbmDisplayHandle {
     /// Create a new handle to a device.
     ///
@@ -294,6 +324,12 @@ pub struct GbmWindowHandle {
     /// The gbm surface.
     pub gbm_surface: NonNull<c_void>,
 }
+
+// SAFETY: GBM is thread safe.
+//
+// TODO: Documentation for this?
+unsafe impl Send for GbmWindowHandle {}
+unsafe impl Sync for GbmWindowHandle {}
 
 impl GbmWindowHandle {
     /// Create a new handle to a surface.

--- a/src/web.rs
+++ b/src/web.rs
@@ -76,6 +76,10 @@ pub struct WebCanvasWindowHandle {
     pub obj: NonNull<c_void>,
 }
 
+// SAFETY: Only accessible from the main thread.
+unsafe impl Send for WebCanvasWindowHandle {}
+unsafe impl Sync for WebCanvasWindowHandle {}
+
 impl WebCanvasWindowHandle {
     /// Create a new handle from a pointer to [`HtmlCanvasElement`].
     ///
@@ -121,6 +125,8 @@ impl WebCanvasWindowHandle {
     ///
     /// The inner pointer must be valid. This is ensured if this handle was
     /// borrowed from [`WindowHandle`][crate::WindowHandle].
+    ///
+    /// Additionally, the current thread must be the main thread.
     pub unsafe fn as_wasm_bindgen_0_2(&self) -> &wasm_bindgen::JsValue {
         unsafe { self.obj.cast().as_ref() }
     }
@@ -130,6 +136,10 @@ impl WebCanvasWindowHandle {
 /// [`wasm-bindgen`].
 ///
 /// [`wasm-bindgen`]: https://crates.io/crates/wasm-bindgen
+///
+/// Note that while this is `Send + Sync`, it is only usable from the main
+/// thread. Any usage of `JsValue` outside the main thread is undefined
+/// behaviour.
 #[non_exhaustive]
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub struct WebOffscreenCanvasWindowHandle {
@@ -144,6 +154,10 @@ pub struct WebOffscreenCanvasWindowHandle {
     // SAFETY: See WebCanvasWindowHandle.
     pub obj: NonNull<c_void>,
 }
+
+// SAFETY: Only accessible from the main thread.
+unsafe impl Send for WebOffscreenCanvasWindowHandle {}
+unsafe impl Sync for WebOffscreenCanvasWindowHandle {}
 
 impl WebOffscreenCanvasWindowHandle {
     /// Create a new handle from a pointer to an [`OffscreenCanvas`].
@@ -191,6 +205,8 @@ impl WebOffscreenCanvasWindowHandle {
     ///
     /// The inner pointer must be valid. This is ensured if this handle was
     /// borrowed from [`WindowHandle`][crate::WindowHandle].
+    ///
+    /// Additionally, the current thread must be the main thread.
     pub unsafe fn as_wasm_bindgen_0_2(&self) -> &wasm_bindgen::JsValue {
         unsafe { self.obj.cast().as_ref() }
     }

--- a/src/windows.rs
+++ b/src/windows.rs
@@ -63,12 +63,19 @@ impl Win32WindowHandle {
 }
 
 /// Raw window handle for WinRT.
+///
+/// This handle is `Send + Sync`, but it is unknown whether that is actually
+/// sound.
 #[non_exhaustive]
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub struct WinRtWindowHandle {
     /// A WinRT `CoreWindow` handle.
     pub core_window: NonNull<c_void>,
 }
+
+// SAFETY: Unknown.
+unsafe impl Send for WinRtWindowHandle {}
+unsafe impl Sync for WinRtWindowHandle {}
 
 impl WinRtWindowHandle {
     /// Create a new handle to a window.


### PR DESCRIPTION
In `winit` we're currently discussing this, both in https://github.com/rust-windowing/winit/pull/3136 and [on Matrix](https://matrix.to/#/!DGpLzJTRzBDTwZiogk:matrix.org/$3ZmHgbmQ6830krosfesFzpRw_nquUQ8XZte5jSilAes?via=libera.chat&via=matrix.org&via=ralith.com). See also previous discussion in https://github.com/rust-windowing/raw-window-handle/issues/59, and the related issue in https://github.com/rust-windowing/raw-window-handle/issues/85.

So I've opened this PR to see what it would take to make the handles `Send + Sync`, which would be somewhat possible on macOS, iOS and the web (provided that users uphold the "only use this on the main thread" requirement, which one could argue might be a safety footgun) - though I'm unsure if it's actually safe on the other platforms?

In any case we need to do _something_, because `winit::Window` is `Send + Sync`, and it unconditionally implements `HasWindowHandle`, so users could always just send the window to another thread and get a handle from that.

Fixes https://github.com/rust-windowing/raw-window-handle/issues/85 and fixes https://github.com/rust-windowing/raw-window-handle/issues/147.

TODO:
- [ ] Changelog entry
- [ ] Fix todos about safety comments