### PR TITLE
Improve documentation for UIKit and AppKit handles

### DIFF
--- a/src/appkit.rs
+++ b/src/appkit.rs
@@ -48,6 +48,41 @@ impl DisplayHandle<'static> {
 /// Note that `NSView` can only be accessed from the main thread of the
 /// application. This struct is `!Send` and `!Sync` to help with ensuring
 /// that.
+///
+/// # Example
+///
+/// Getting the view from a [`WindowHandle`][crate::WindowHandle].
+///
+/// ```no_run
+/// # fn inner() {
+/// #![cfg(target_os = "macos")]
+/// # #[cfg(requires_objc2)]
+/// use icrate::AppKit::NSView;
+/// # #[cfg(requires_objc2)]
+/// use icrate::Foundation::is_main_thread;
+/// # #[cfg(requires_objc2)]
+/// use objc2::rc::Id;
+/// use raw_window_handle::{WindowHandle, RawWindowHandle};
+///
+/// let handle: WindowHandle<'_>; // Get the window handle from somewhere else
+/// # handle = unimplemented!();
+/// match handle.as_raw() {
+///     # #[cfg(requires_objc2)]
+///     RawWindowHandle::AppKit(handle) => {
+///         assert!(is_main_thread(), "can only access AppKit handles on the main thread");
+///         let ns_view = handle.ns_view.as_ptr();
+///         // SAFETY: The pointer came from `WindowHandle`, which ensures
+///         // that the `AppKitWindowHandle` contains a valid pointer to an
+///         // `NSView`.
+///         // Unwrap is fine, since the pointer came from `NonNull`.
+///         let ns_view: Id<NSView> = unsafe { Id::retain(ns_view.cast()) }.unwrap();
+///         // Do something with the NSView here, like getting the `NSWindow`
+///         let ns_window = ns_view.window().expect("view was not installed in a window");
+///     }
+///     handle => unreachable!("unknown handle {handle:?} for platform"),
+/// }
+/// # }
+/// ```
 #[non_exhaustive]
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub struct AppKitWindowHandle {

--- a/src/appkit.rs
+++ b/src/appkit.rs
@@ -44,6 +44,10 @@ impl DisplayHandle<'static> {
 }
 
 /// Raw window handle for AppKit.
+///
+/// Note that `NSView` can only be accessed from the main thread of the
+/// application. This struct is `!Send` and `!Sync` to help with ensuring
+/// that.
 #[non_exhaustive]
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub struct AppKitWindowHandle {

--- a/src/uikit.rs
+++ b/src/uikit.rs
@@ -44,6 +44,10 @@ impl DisplayHandle<'static> {
 }
 
 /// Raw window handle for UIKit.
+///
+/// Note that `UIView` can only be accessed from the main thread of the
+/// application. This struct is `!Send` and `!Sync` to help with ensuring
+/// that.
 #[non_exhaustive]
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub struct UiKitWindowHandle {

--- a/src/uikit.rs
+++ b/src/uikit.rs
@@ -48,6 +48,41 @@ impl DisplayHandle<'static> {
 /// Note that `UIView` can only be accessed from the main thread of the
 /// application. This struct is `!Send` and `!Sync` to help with ensuring
 /// that.
+///
+/// # Example
+///
+/// Getting the view from a [`WindowHandle`][crate::WindowHandle].
+///
+/// ```no_run
+/// # fn inner() {
+/// #![cfg(any(target_os = "ios", target_os = "tvos", target_os = "watchos", target_os = "xros"))]
+/// # #[cfg(requires_objc2)]
+/// use icrate::Foundation::is_main_thread;
+/// # #[cfg(requires_objc2)]
+/// use objc2::rc::Id;
+/// // TODO: Use `icrate::UIKit::UIView` when available
+/// # #[cfg(requires_objc2)]
+/// use objc2::runtime::NSObject;
+/// use raw_window_handle::{WindowHandle, RawWindowHandle};
+///
+/// let handle: WindowHandle<'_>; // Get the window handle from somewhere else
+/// # handle = unimplemented!();
+/// match handle.as_raw() {
+///     # #[cfg(requires_objc2)]
+///     RawWindowHandle::UIKit(handle) => {
+///         assert!(is_main_thread(), "can only access UIKit handles on the main thread");
+///         let ui_view = handle.ui_view.as_ptr();
+///         // SAFETY: The pointer came from `WindowHandle`, which ensures
+///         // that the `UiKitWindowHandle` contains a valid pointer to an
+///         // `UIView`.
+///         // Unwrap is fine, since the pointer came from `NonNull`.
+///         let ui_view: Id<NSObject> = unsafe { Id::retain(ui_view.cast()) }.unwrap();
+///         // Do something with the UIView here.
+///     }
+///     handle => unreachable!("unknown handle {handle:?} for platform"),
+/// }
+/// # }
+/// ```
 #[non_exhaustive]
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub struct UiKitWindowHandle {


### PR DESCRIPTION
This takes part of the main thread only docs from https://github.com/rust-windowing/raw-window-handle/pull/154, but with the less strong guarantee of the handle only ever _existing_ on the main thread (as that's probably not yet true in the wild, so I'd rather have consumers to the extra check).