### PR TITLE
Add MSRV policy regarding wasm-bindgen

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,7 +42,7 @@ jobs:
       - run: rustup target add wasm32-unknown-unknown
 
       - name: Pin deps that break MSRV
-        if: matrix.rust_version == '1.64.0'
+        if: matrix.rust_version == '1.64'
         run: |
           cargo update -p exr --precise 1.71.0
           cargo update -p ahash --precise 0.8.7

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,8 +44,6 @@ jobs:
       - name: Pin deps that break MSRV
         if: matrix.rust_version == '1.64'
         run: |
-          cargo update -p exr --precise 1.71.0
-          cargo update -p ahash --precise 0.8.7
           cargo update -p bumpalo --precise 3.14.0
 
       - name: Check documentation

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,9 +51,9 @@ jobs:
 
       - name: Run tests for wasm32-unknown-unknown
         run: cargo hack check --target wasm32-unknown-unknown --feature-powerset
-        if: matrix.rust_version != "1.64"
+        if: matrix.rust_version != '1.64'
 
       - name: Run tests for wasm32-unknown-unknown
         run: cargo hack check --target wasm32-unknown-unknown --feature-powerset --skip wasm-bindgen-0-2
-        if: matrix.rust_version -= "1.64"
+        if: matrix.rust_version == '1.64'
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,7 +31,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        rust_version: ["1.64", stable, nightly]
+        rust_version: ["1.64", "1.73", stable, nightly]
 
     steps:
       - uses: actions/checkout@v2
@@ -51,4 +51,9 @@ jobs:
 
       - name: Run tests for wasm32-unknown-unknown
         run: cargo hack check --target wasm32-unknown-unknown --feature-powerset
+        if: matrix.rust_version != "1.64"
+
+      - name: Run tests for wasm32-unknown-unknown
+        run: cargo hack check --target wasm32-unknown-unknown --feature-powerset --skip wasm-bindgen-0-2
+        if: matrix.rust_version -= "1.64"
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,7 +31,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        rust_version: ["1.64", "1.73", stable, nightly]
+        rust_version: ["1.64", stable, nightly]
 
     steps:
       - uses: actions/checkout@v2
@@ -40,6 +40,13 @@ jobs:
         with:
           rust-version: ${{ matrix.rust_version }}
       - run: rustup target add wasm32-unknown-unknown
+
+      - name: Pin deps that break MSRV
+        if: matrix.rust_version == '1.64.0'
+        run: |
+          cargo update -p exr --precise 1.71.0
+          cargo update -p ahash --precise 0.8.7
+          cargo update -p bumpalo --precise 3.14.0
 
       - name: Check documentation
         run: cargo doc --no-deps --document-private-items
@@ -51,9 +58,3 @@ jobs:
 
       - name: Run tests for wasm32-unknown-unknown
         run: cargo hack check --target wasm32-unknown-unknown --feature-powerset
-        if: matrix.rust_version != '1.64'
-
-      - name: Run tests for wasm32-unknown-unknown
-        run: cargo hack check --target wasm32-unknown-unknown --feature-powerset --skip wasm-bindgen-0-2
-        if: matrix.rust_version == '1.64'
-

--- a/README.md
+++ b/README.md
@@ -9,3 +9,14 @@ raw window handle and display's platform-specific raw display handle. This does
 not provide any utilities for creating and managing windows; instead, it
 provides a common interface that window creation libraries (e.g. Winit, SDL)
 can use to easily talk with graphics libraries (e.g. gfx-hal).
+
+## MSRV Policy
+
+The Minimum Safe Rust Version (MSRV) of this crate as of the time of writing is
+**1.64.0**. For pre-`1.0` releases of `raw-window-handle`, this version will not
+be changed without a patch bump to the version of `raw-window-handle`. After
+version `1.0.0` is released, changes to the MSRV will necessitate a minor
+version bump.
+
+When the `wasm-bindgen-0-2` feature is enabled, the MSRV of this crate will be
+raised to the MSRV of the latest version of `wasm-bindgen`.


### PR DESCRIPTION
wasm-bindgen recently bumped its MSRV to v1.73, which is much higher
than our MSRV of 1.64. Add an note to the README describing our MSRV
policy, and then test for it in CI.

----

cc @daxpedda
