### PR TITLE
Clarify Win32 handle validity

### DIFF
--- a/src/windows.rs
+++ b/src/windows.rs
@@ -59,6 +59,10 @@ pub struct Win32WindowHandle {
 impl Win32WindowHandle {
     /// Create a new handle to a window.
     ///
+    /// # Safety
+    /// 
+    /// It is assumed that the Win32 handle belongs to the current thread. This
+    /// is necessary for the handle to be considered "valid" in all cases.
     ///
     /// # Example
     ///

--- a/src/windows.rs
+++ b/src/windows.rs
@@ -60,7 +60,7 @@ impl Win32WindowHandle {
     /// Create a new handle to a window.
     ///
     /// # Safety
-    /// 
+    ///
     /// It is assumed that the Win32 handle belongs to the current thread. This
     /// is necessary for the handle to be considered "valid" in all cases.
     ///


### PR DESCRIPTION
This commit clarifies what is expected by the system for a Win32 handle.
It is expected that the Win32 handle belongs to the current thread. This
is not a breaking change as it was previously necessary for the window
to be considered "valid".

cc https://github.com/rust-windowing/winit/pull/3593
