### PR TITLE
Add OpenHarmony OS support

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -135,7 +135,7 @@ pub enum RawWindowHandle {
     /// A raw window handle for the OpenHarmony OS NDK
     ///
     /// ## Availability Hints
-    /// This variant is used on OpenHarmony OS ( `target_env = "ohos"`).
+    /// This variant is used on OpenHarmony OS (`target_env = "ohos"`).
     OhosNdk(OhosNdkWindowHandle),
     /// A raw window handle for Xlib.
     ///
@@ -288,7 +288,7 @@ pub enum RawDisplayHandle {
     /// A raw display handle for OpenHarmony OS NDK
     ///
     /// ## Availability Hints
-    /// This variant is used on OpenHarmony OS ( `target_env = "ohos"`).
+    /// This variant is used on OpenHarmony OS (`target_env = "ohos"`).
     Ohos(OhosDisplayHandle),
     /// A raw display handle for Xlib.
     ///

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -37,6 +37,7 @@ mod android;
 mod appkit;
 mod borrowed;
 mod haiku;
+mod ohos;
 mod redox;
 mod uikit;
 mod unix;
@@ -47,6 +48,7 @@ pub use android::{AndroidDisplayHandle, AndroidNdkWindowHandle};
 pub use appkit::{AppKitDisplayHandle, AppKitWindowHandle};
 pub use borrowed::{DisplayHandle, HasDisplayHandle, HasWindowHandle, WindowHandle};
 pub use haiku::{HaikuDisplayHandle, HaikuWindowHandle};
+pub use ohos::{OhosDisplayHandle, OhosNdkWindowHandle};
 pub use redox::{OrbitalDisplayHandle, OrbitalWindowHandle};
 pub use uikit::{UiKitDisplayHandle, UiKitWindowHandle};
 pub use unix::{
@@ -130,6 +132,11 @@ pub enum RawWindowHandle {
     /// This variant is used by the Orbital Windowing System in the Redox
     /// operating system.
     Orbital(OrbitalWindowHandle),
+    /// A raw window handle for the OpenHarmony OS NDK
+    ///
+    /// ## Availability Hints
+    /// This variant is used on OpenHarmony OS ( `target_env = "ohos"`).
+    OhosNdk(OhosNdkWindowHandle),
     /// A raw window handle for Xlib.
     ///
     /// ## Availability Hints
@@ -278,6 +285,11 @@ pub enum RawDisplayHandle {
     /// This variant is used by the Orbital Windowing System in the Redox
     /// operating system.
     Orbital(OrbitalDisplayHandle),
+    /// A raw display handle for OpenHarmony OS NDK
+    ///
+    /// ## Availability Hints
+    /// This variant is used on OpenHarmony OS ( `target_env = "ohos"`).
+    Ohos(OhosDisplayHandle),
     /// A raw display handle for Xlib.
     ///
     /// ## Availability Hints
@@ -391,6 +403,7 @@ macro_rules! from_impl {
 from_impl!(RawDisplayHandle, UiKit, UiKitDisplayHandle);
 from_impl!(RawDisplayHandle, AppKit, AppKitDisplayHandle);
 from_impl!(RawDisplayHandle, Orbital, OrbitalDisplayHandle);
+from_impl!(RawDisplayHandle, Ohos, OhosDisplayHandle);
 from_impl!(RawDisplayHandle, Xlib, XlibDisplayHandle);
 from_impl!(RawDisplayHandle, Xcb, XcbDisplayHandle);
 from_impl!(RawDisplayHandle, Wayland, WaylandDisplayHandle);
@@ -404,6 +417,7 @@ from_impl!(RawDisplayHandle, Haiku, HaikuDisplayHandle);
 from_impl!(RawWindowHandle, UiKit, UiKitWindowHandle);
 from_impl!(RawWindowHandle, AppKit, AppKitWindowHandle);
 from_impl!(RawWindowHandle, Orbital, OrbitalWindowHandle);
+from_impl!(RawWindowHandle, OhosNdk, OhosNdkWindowHandle);
 from_impl!(RawWindowHandle, Xlib, XlibWindowHandle);
 from_impl!(RawWindowHandle, Xcb, XcbWindowHandle);
 from_impl!(RawWindowHandle, Wayland, WaylandWindowHandle);
@@ -444,6 +458,7 @@ mod tests {
         assert_impl_all!(UiKitDisplayHandle: Send, Sync);
         assert_impl_all!(AppKitDisplayHandle: Send, Sync);
         assert_impl_all!(OrbitalDisplayHandle: Send, Sync);
+        assert_impl_all!(OhosDisplayHandle: Send, Sync);
         assert_not_impl_any!(XlibDisplayHandle: Send, Sync);
         assert_not_impl_any!(XcbDisplayHandle: Send, Sync);
         assert_not_impl_any!(WaylandDisplayHandle: Send, Sync);
@@ -458,6 +473,7 @@ mod tests {
         assert_not_impl_any!(UiKitWindowHandle: Send, Sync);
         assert_not_impl_any!(AppKitWindowHandle: Send, Sync);
         assert_not_impl_any!(OrbitalWindowHandle: Send, Sync);
+        assert_not_impl_any!(OhosNdkWindowHandle: Send, Sync);
         assert_impl_all!(XlibWindowHandle: Send, Sync);
         assert_impl_all!(XcbWindowHandle: Send, Sync);
         assert_not_impl_any!(WaylandWindowHandle: Send, Sync);

--- a/src/ohos.rs
+++ b/src/ohos.rs
@@ -1,0 +1,98 @@
+//! [OpenHarmony] OS Window Handles
+//!
+//! ## Background
+//!
+//! Applications on [OpenHarmony] use [ArkUI] for defining their UI. Applications can use an
+//! [XComponent] to render using native Code (e.g. Rust) via EGL.
+//! Native code will receive a callback `OnSurfaceCreatedCB(OH_NativeXComponent *component, void *window)`
+//! when the `XComponent` is created. The window argument has the type [`OHNativeWindow`] / `EGLNativeWindowType`.
+//! The window can then be used to create a surface with
+//! `eglCreateWindowSurface(eglDisplay_, eglConfig_, window, NULL)`
+//!
+//! [OpenHarmony]: https://gitee.com/openharmony/docs/blob/master/en/OpenHarmony-Overview.md
+//! [ArkUI]: https://gitee.com/openharmony/docs/blob/master/en/application-dev/ui/arkui-overview.md
+//! [XComponent]: https://gitee.com/openharmony/docs/blob/master/en/application-dev/ui/arkts-common-components-xcomponent.md
+//! [`OHNativeWindow`]: https://gitee.com/openharmony/docs/blob/master/en/application-dev/reference/apis-arkgraphics2d/_native_window.md
+
+use core::ffi::c_void;
+use core::ptr::NonNull;
+
+use super::DisplayHandle;
+
+/// Raw display handle for OpenHarmony.
+#[non_exhaustive]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub struct OhosDisplayHandle {}
+
+impl OhosDisplayHandle {
+    /// Create a new empty display handle.
+    ///
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// # use raw_window_handle::OhosDisplayHandle;
+    /// let handle = OhosDisplayHandle::new();
+    /// ```
+    pub fn new() -> Self {
+        Self {}
+    }
+}
+
+impl DisplayHandle<'static> {
+    /// Create an OpenHarmony-based display handle.
+    ///
+    /// As no data is borrowed by this handle, it is completely safe to create. This function
+    /// may be useful to windowing framework implementations that want to avoid unsafe code.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// # use raw_window_handle::{DisplayHandle, HasDisplayHandle};
+    /// # fn do_something(rwh: impl HasDisplayHandle) { let _ = rwh; }
+    /// let handle = DisplayHandle::ohos();
+    /// do_something(handle);
+    /// ```
+    pub fn ohos() -> Self {
+        // SAFETY: No data is borrowed.
+        unsafe { Self::borrow_raw(OhosDisplayHandle::new().into()) }
+    }
+}
+
+/// Raw window handle for Ohos NDK.
+#[non_exhaustive]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub struct OhosNdkWindowHandle {
+    pub native_window: NonNull<c_void>,
+}
+
+impl OhosNdkWindowHandle {
+    /// Create a new handle to an [`OHNativeWindow`] on OpenHarmony.
+    ///
+    /// The handle will typically be created from an [`XComponent`], consult the
+    /// [native `XComponent` Guidelines] for more details.
+    ///
+    /// [`XComponent`]: https://gitee.com/openharmony/docs/blob/master/en/application-dev/ui/arkts-common-components-xcomponent.md
+    /// [native `XComponent` Guidelines]: https://gitee.com/openharmony/docs/blob/OpenHarmony-4.0-Release/en/application-dev/napi/xcomponent-guidelines.md
+    /// [`OHNativeWindow`]: https://gitee.com/openharmony/docs/blob/master/en/application-dev/reference/apis-arkgraphics2d/_native_window.md
+    /// # Example
+    ///
+    /// ```
+    /// # use core::ptr::NonNull;
+    /// # use core::ffi::c_void;
+    /// # use raw_window_handle::OhosNdkWindowHandle;
+    /// # #[allow(non_camel_case_types)]
+    /// # type OH_NativeXComponent = ();
+    ///
+    /// /// Called When the `XComponent` is created.
+    /// ///
+    /// /// See the [XComponent Guidelines](https://gitee.com/openharmony/docs/blob/OpenHarmony-4.0-Release/en/application-dev/napi/xcomponent-guidelines.md)
+    /// /// for more details
+    /// extern "C" fn on_surface_created_callback(component: *mut OH_NativeXComponent, window: *mut c_void) {
+    ///     let handle = OhosNdkWindowHandle::new(NonNull::new(window).unwrap());
+    /// }
+    /// ```
+    pub fn new(native_window: NonNull<c_void>) -> Self {
+        Self { native_window }
+    }
+}


### PR DESCRIPTION
Add support for the [OpenHarmony] operating system, which is a [tier-2 target] in Rust starting with
Rust 1.78.
On OpenHarmony [ArkUI] is used to develop
applications. ArkUI provides the [XComponent]
type, which allows native code (e.g. Rust) to use
EGL / OpenGL ES to render directly to a native
window.

[tier-2 target]: https://doc.rust-lang.org/nightly/rustc/platform-support/openharmony.html
[OpenHarmony]: https://gitee.com/openharmony/docs/blob/master/en/OpenHarmony-Overview.md
[ArkUI]: https://gitee.com/openharmony/docs/blob/master/en/application-dev/ui/arkui-overview.md
[XComponent]: https://gitee.com/openharmony/docs/blob/master/en/application-dev/ui/arkts-common-components-xcomponent.md