### PR TITLE
v0.6.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## 0.6.1 (2024-04-20)
+
+- Add safe constructors for window handles. This may be useful for implementing
+  windowing systems with zero unsafe code. (#159)
+- Improve documentation for Apple window handles. (#160)
+- Add a clarification as to what circumstances Windows handles are considered
+  "valid" under. (#163)
+
 ## 0.6.0 (2023-09-30)
 
 * **Breaking:** Raw pointer handles now use `NonNull` where appropriate, to avoid null pointer dereferences.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "raw-window-handle"
-version = "0.6.0"
+version = "0.6.1"
 authors = ["Osspial <osspial@gmail.com>"]
 edition = "2021"
 description = "Interoperability library for Rust Windowing applications."


### PR DESCRIPTION
- Add safe constructors for window handles. This may be useful for implementing
  windowing systems with zero unsafe code. (#159)
- Improve documentation for Apple window handles. (#160)
- Add a clarification as to what circumstances Windows handles are considered
  "valid" under. (#163)
