### PR TITLE
Update Changelog and bump version number

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 0.6.2 (2024-05-17)
+
+* Add OpenHarmony OS support (#164)
+* Minor Documentation updates
+
 ## 0.6.1 (2024-04-20)
 
 - Add safe constructors for window handles. This may be useful for implementing

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "raw-window-handle"
-version = "0.6.1"
+version = "0.6.2"
 authors = ["Osspial <osspial@gmail.com>"]
 edition = "2021"
 description = "Interoperability library for Rust Windowing applications."


### PR DESCRIPTION
It would be nice (for me) if there could be a new Release containing #164.
I just went ahead and put todays date in the Changelog, but I can also change it to `## unreleased` or something else.