### PR TITLE
Add connector_id to DrmWindowHandle

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## Unreleased
+
+* Add optional connector_id field to DrmWindowHandle (#170)
+
 ## 0.6.2 (2024-05-17)
 
 * Add OpenHarmony OS support (#164)

--- a/src/unix.rs
+++ b/src/unix.rs
@@ -275,7 +275,7 @@ impl DrmWindowHandle {
     /// let plane: u32;
     /// # plane = 0;
     /// let connector_id: NonZeroU32;
-    /// # connect_id = unsafe { NonZeroU32::new_unchecked(1) };
+    /// # connector_id = unsafe { NonZeroU32::new_unchecked(1) };
     /// let handle = DrmWindowHandle::new_with_connector_id(plane, connector_id);
     /// ```
     pub fn new_with_connector_id(plane: u32, connector_id: NonZeroU32) -> Self {

--- a/src/unix.rs
+++ b/src/unix.rs
@@ -239,6 +239,7 @@ impl DrmDisplayHandle {
 pub struct DrmWindowHandle {
     /// The primary drm plane handle.
     pub plane: u32,
+    /// An optional handle to chosen drm connector
     pub connector_id: Option<NonZeroU32>,
 }
 

--- a/src/unix.rs
+++ b/src/unix.rs
@@ -213,6 +213,7 @@ pub struct DrmDisplayHandle {
     /// The drm file descriptor.
     // TODO: Use `std::os::fd::RawFd`?
     pub fd: i32,
+    pub connector_id: u32,
 }
 
 impl DrmDisplayHandle {
@@ -228,8 +229,8 @@ impl DrmDisplayHandle {
     /// # fd = 0;
     /// let handle = DrmDisplayHandle::new(fd);
     /// ```
-    pub fn new(fd: i32) -> Self {
-        Self { fd }
+    pub fn new(fd: i32, connector_id: u32) -> Self {
+        Self { fd, connector_id }
     }
 }
 

--- a/src/unix.rs
+++ b/src/unix.rs
@@ -213,7 +213,6 @@ pub struct DrmDisplayHandle {
     /// The drm file descriptor.
     // TODO: Use `std::os::fd::RawFd`?
     pub fd: i32,
-    pub connector_id: u32,
 }
 
 impl DrmDisplayHandle {
@@ -226,13 +225,11 @@ impl DrmDisplayHandle {
     /// # use raw_window_handle::DrmDisplayHandle;
     /// #
     /// let fd: i32;
-    /// let connector_id: u32;
     /// # fd = 0;
-    /// # connector_id = 0;
-    /// let handle = DrmDisplayHandle::new(fd, connector_id);
+    /// let handle = DrmDisplayHandle::new(fd);
     /// ```
-    pub fn new(fd: i32, connector_id: u32) -> Self {
-        Self { fd, connector_id }
+    pub fn new(fd: i32) -> Self {
+        Self { fd }
     }
 }
 
@@ -242,6 +239,7 @@ impl DrmDisplayHandle {
 pub struct DrmWindowHandle {
     /// The primary drm plane handle.
     pub plane: u32,
+    pub connector_id: Option<NonZeroU32>,
 }
 
 impl DrmWindowHandle {
@@ -258,7 +256,10 @@ impl DrmWindowHandle {
     /// let handle = DrmWindowHandle::new(plane);
     /// ```
     pub fn new(plane: u32) -> Self {
-        Self { plane }
+        Self {
+            plane,
+            connector_id: None,
+        }
     }
 }
 

--- a/src/unix.rs
+++ b/src/unix.rs
@@ -262,6 +262,28 @@ impl DrmWindowHandle {
             connector_id: None,
         }
     }
+
+    /// Create a new handle to a plane and associated connector_id.
+    ///
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// # use raw_window_handle::DrmWindowHandle;
+    /// # use core::num::NonZeroU32;
+    /// #
+    /// let plane: u32;
+    /// # plane = 0;
+    /// let connector_id: NonZeroU32;
+    /// # connect_id = unsafe { NonZeroU32::new_unchecked(1) };
+    /// let handle = DrmWindowHandle::new_with_connector_id(plane, connector_id);
+    /// ```
+    pub fn new_with_connector_id(plane: u32, connector_id: NonZeroU32) -> Self {
+        Self {
+            plane,
+            connector_id: Some(connector_id),
+        }
+    }
 }
 
 /// Raw display handle for the Linux Generic Buffer Manager.

--- a/src/unix.rs
+++ b/src/unix.rs
@@ -226,8 +226,10 @@ impl DrmDisplayHandle {
     /// # use raw_window_handle::DrmDisplayHandle;
     /// #
     /// let fd: i32;
+    /// let connector_id: u32;
     /// # fd = 0;
-    /// let handle = DrmDisplayHandle::new(fd);
+    /// # connector_id = 0;
+    /// let handle = DrmDisplayHandle::new(fd, connector_id);
     /// ```
     pub fn new(fd: i32, connector_id: u32) -> Self {
         Self { fd, connector_id }


### PR DESCRIPTION
This pull request introduces a new field to the DRM display handle to specify the connector id.

Rationale:
Without a connector, the file descriptor may point to a DRM device that lacks any connected displays, rendering it non-functional and arguably not a valid handle. By adding the connector_id field, we ensure that the display handle accurately represents a connected and usable display.