### PR TITLE
Deprecate `UiKitWindowHandle::ui_view_controller`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Unreleased
 
 * Improve documentation on AppKit and UIKit handles.
+* Deprecated `UiKitWindowHandle::ui_view_controller`, retrieve this from the UIView's responder chain instead.
 
 ## 0.6.2 (2024-05-17)
 

--- a/src/uikit.rs
+++ b/src/uikit.rs
@@ -88,6 +88,32 @@ pub struct UiKitWindowHandle {
     /// A pointer to an `UIView` object.
     pub ui_view: NonNull<c_void>,
     /// A pointer to an `UIViewController` object, if the view has one.
+    ///
+    /// This is deprecated, the controller should be retrieved by traversing the `UIView`'s\
+    /// responder chain instead:
+    ///
+    /// ```ignore
+    /// use objc2::rc::Retained;
+    /// use objc2_ui_kit::{UIResponder, UIView, UIViewController};
+    ///
+    /// let view: Retained<UIView> = ...;
+    ///
+    /// let mut current_responder: Retained<UIResponder> = view.into_super();
+    /// let mut found_controller = None;
+    /// while let Some(responder) = unsafe { current_responder.nextResponder() } {
+    ///     match responder.downcast::<UIViewController>() {
+    ///         Ok(controller) => {
+    ///             found_controller = Some(controller);
+    ///             break;
+    ///         }
+    ///         // Search next.
+    ///         Err(responder) => current_responder = responder,
+    ///     }
+    /// }
+    ///
+    /// // Use found_controller here.
+    /// ```
+    #[deprecated = "retrieve the view controller from the UIView's responder chain instead"]
     pub ui_view_controller: Option<NonNull<c_void>>,
 }
 
@@ -107,11 +133,10 @@ impl UiKitWindowHandle {
     ///
     /// let ui_view: Retained<UIView> = ...;
     /// let ui_view: NonNull<UIView> = NonNull::from(&*ui_view);
-    /// let mut handle = UiKitWindowHandle::new(ui_view.cast());
-    /// // Optionally, set the view controller too.
-    /// handle.ui_view_controller = None;
+    /// let handle = UiKitWindowHandle::new(ui_view.cast());
     /// ```
     pub fn new(ui_view: NonNull<c_void>) -> Self {
+        #[allow(deprecated)]
         Self {
             ui_view,
             ui_view_controller: None,


### PR DESCRIPTION
This can be retrieved from the `UIView` itself, and is hence unnecessary information for us to carry around.

Besides, since it's optional, users that want to get the view controller has to do the searching logic anyways.

Once we remove this in the next breaking version, we should move the example code I've provided on `ui_view_controller` here to an example instead.