### PR TITLE
breaking: Remove wasm-bindgen from public API

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,9 +51,14 @@ jobs:
         run: cargo doc --no-deps --document-private-items
 
       - uses: taiki-e/install-action@cargo-hack
+      - uses: taiki-e/install-action@wasm-pack
 
       - name: Run tests
         run: cargo hack test --feature-powerset
 
       - name: Run tests for wasm32-unknown-unknown
         run: cargo hack check --target wasm32-unknown-unknown --feature-powerset
+
+      - name: Run tests inside of Chrome
+        run: wasm-pack test --chrome --headless
+        if: matrix.rust_version != '1.64'

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,6 +18,19 @@ std = ["alloc"]
 [dev-dependencies]
 static_assertions = "1.1.0"
 
+[target.'cfg(target_family = "wasm")'.dev-dependencies.wasm-bindgen]
+version = "0.2.87"
+default-features = false
+features = ["std"]
+
+[target.'cfg(target_family = "wasm")'.dev-dependencies.web-sys]
+version = "0.3.85"
+default-features = false
+features = ["HtmlCanvasElement", "OffscreenCanvas", "Window", "Document"]
+
+[target.'cfg(target_family = "wasm")'.dev-dependencies]
+wasm-bindgen-test = "0.3"
+
 [package.metadata.docs.rs]
 all-features = true
 rustdoc-args = ["--cfg", "docsrs"]

--- a/src/web.rs
+++ b/src/web.rs
@@ -96,11 +96,24 @@ impl WebCanvasWindowHandle {
     ///
     /// # Example
     ///
-    /// ```
+    #[cfg_attr(target_family = "wasm", doc = "```no_run")]
+    #[cfg_attr(not(target_family = "wasm"), doc = "```no_compile")]
     /// # use raw_window_handle::WebCanvasWindowHandle;
-    /// let value: usize;
-    /// # value = 0;
-    /// let mut handle = WebCanvasWindowHandle::new(value);
+    /// use core::mem::ManuallyDrop;
+    /// use wasm_bindgen::convert::{IntoWasmAbi, RefFromWasmAbi};
+    /// use web_sys::HtmlCanvasElement;
+    ///
+    /// let value: HtmlCanvasElement;
+    /// # value = todo!();
+    ///
+    /// // Convert to the raw index and convert to the handle.
+    /// let index = (&value).into_abi();
+    /// let mut handle = WebCanvasWindowHandle::new(index as usize);
+    ///
+    /// // To get the canvas element back, convert the index back.
+    /// let other_end: ManuallyDrop<HtmlCanvasElement> = unsafe {
+    ///     HtmlCanvasElement::ref_from_abi(handle.obj as u32)
+    /// };
     /// ```
     pub fn new(obj: usize) -> Self {
         Self {
@@ -134,11 +147,24 @@ impl WebOffscreenCanvasWindowHandle {
     ///
     /// # Example
     ///
-    /// ```
+    #[cfg_attr(target_family = "wasm", doc = "```no_run")]
+    #[cfg_attr(not(target_family = "wasm"), doc = "```no_compile")]
     /// # use raw_window_handle::WebOffscreenCanvasWindowHandle;
-    /// let value: usize;
-    /// # value = 0;
-    /// let mut handle = WebOffscreenCanvasWindowHandle::new(value);
+    /// use core::mem::ManuallyDrop;
+    /// use wasm_bindgen::convert::{IntoWasmAbi, RefFromWasmAbi};
+    /// use web_sys::OffscreenCanvas;
+    ///
+    /// let value: OffscreenCanvas;
+    /// # value = todo!();
+    ///
+    /// // Convert to the raw index and convert to the handle.
+    /// let index = (&value).into_abi();
+    /// let handle = WebOffscreenCanvasWindowHandle::new(index as usize);
+    ///
+    /// // To get the canvas element back, convert the index back.
+    /// let other_end: ManuallyDrop<OffscreenCanvas> = unsafe {
+    ///     OffscreenCanvas::ref_from_abi(handle.obj as u32)
+    /// };
     /// ```
     pub fn new(obj: usize) -> Self {
         Self {

--- a/tests/web_handles.rs
+++ b/tests/web_handles.rs
@@ -1,0 +1,49 @@
+//! Tests to ensure web handle examples work correctly.
+
+#![cfg(target_family = "wasm")]
+
+use core::mem::ManuallyDrop;
+use raw_window_handle::{WebCanvasWindowHandle, WebOffscreenCanvasWindowHandle};
+use wasm_bindgen::convert::{IntoWasmAbi, RefFromWasmAbi};
+use wasm_bindgen::JsCast;
+use web_sys::{HtmlCanvasElement, OffscreenCanvas};
+
+#[wasm_bindgen_test::wasm_bindgen_test]
+#[test]
+fn html_canvas_element() {
+    let document = web_sys::window().unwrap().document().unwrap();
+    let canvas: HtmlCanvasElement = document
+        .create_element("canvas")
+        .unwrap()
+        .dyn_into()
+        .unwrap();
+
+    canvas.set_attribute("width", "100").unwrap();
+    canvas.set_attribute("height", "100").unwrap();
+
+    // Convert to the raw index and convert to the handle.
+    let index = (&canvas).into_abi();
+    let handle = WebCanvasWindowHandle::new(index as usize);
+
+    // To get the canvas element back, convert the index back.
+    let other_end: ManuallyDrop<HtmlCanvasElement> =
+        unsafe { HtmlCanvasElement::ref_from_abi(handle.obj as u32) };
+    assert_eq!(&*other_end, &canvas);
+}
+
+#[wasm_bindgen_test::wasm_bindgen_test]
+#[test]
+fn offscreen_canvas() {
+    let canvas = OffscreenCanvas::new(100, 100).unwrap();
+
+    // Convert to the raw index and convert to the handle.
+    let index = (&canvas).into_abi();
+    let handle = WebOffscreenCanvasWindowHandle::new(index as usize);
+
+    // To get the canvas element back, convert the index back.
+    let other_end: ManuallyDrop<OffscreenCanvas> =
+        unsafe { OffscreenCanvas::ref_from_abi(handle.obj as u32) };
+    assert_eq!(&*other_end, &canvas);
+}
+
+wasm_bindgen_test::wasm_bindgen_test_configure!(run_in_browser);


### PR DESCRIPTION
This commit replaces the `JsValue` in the public API
with the underlying index, as per earlier discussion.

Ref: #177

