### PR TITLE
Add a handle for views

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,10 @@
 ## Unreleased
 
 * **Breaking:** Rework web handles to remove `wasm-bindgen` from public API. (#184)
-- **Breaking:** Remove `WebWindowHandle` as it is no longer used. (#186)
+* **Breaking:** Remove `WebWindowHandle` as it is no longer used. (#186)
+* Add `RawViewHandle` and `ViewHandle` to support the separation of views and windows.
+  Graphics APIs should now take `HasViewHandle` instead of `HasWindowHandle` where
+  applicable.
 * Improve documentation on AppKit and UIKit handles.
 * Deprecated `UiKitWindowHandle::ui_view_controller`, retrieve this from the UIView's responder chain instead.
 


### PR DESCRIPTION
This MR adds a handle type specifically for views. "Views" are defined
as sub-areas of windows that graphics APIs can render into. This is
separated from Windows, which may be a key difference for some APIs.

So far this MR only implements views that wrap around windows, and views
that wrap around NSView from AppKit. Discussion must be done to
determine if this is the best way to go about this, as well as if we
should add other views.

Ref: #123

