### PR TITLE
breaking: Change thread safety guarantees for window types

### DIFF
--- a/src/android.rs
+++ b/src/android.rs
@@ -4,6 +4,16 @@ use core::ptr::NonNull;
 use super::DisplayHandle;
 
 /// Raw display handle for Android.
+///
+/// ## Thread Safety
+///
+/// Android native objects are thread-safe by default; therefore this type is
+/// `Send` and `Sync`. This means that this type can be sent to or used from
+/// any thread.
+///
+/// Note that this type does not contain any Android native objects. However,
+/// it is kept `Send` and `Sync` for the event that Android native objects are
+/// added to this type.
 #[non_exhaustive]
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub struct AndroidDisplayHandle {}
@@ -44,12 +54,21 @@ impl DisplayHandle<'static> {
 }
 
 /// Raw window handle for Android NDK.
+///
+/// ## Thread Safety
+///
+/// Android native objects are thread-safe by default; therefore this type is
+/// `Send` and `Sync`. This means that this type can be sent to or used from
+/// any thread.
 #[non_exhaustive]
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub struct AndroidNdkWindowHandle {
     /// A pointer to an `ANativeWindow`.
     pub a_native_window: NonNull<c_void>,
 }
+
+unsafe impl Send for AndroidNdkWindowHandle {}
+unsafe impl Sync for AndroidNdkWindowHandle {}
 
 impl AndroidNdkWindowHandle {
     /// Create a new handle to an `ANativeWindow`.

--- a/src/appkit.rs
+++ b/src/appkit.rs
@@ -1,12 +1,23 @@
 use core::ffi::c_void;
+use core::marker::PhantomData;
 use core::ptr::NonNull;
 
 use super::DisplayHandle;
 
 /// Raw display handle for AppKit.
+///
+/// ## Thread Safety
+///
+/// This type has the safe thread safety guarantees as [`AppKitWindowHandle`].
+///
+/// Note that this type does not contain any Appkit objects. However,
+/// it is kept `!Send` and `!Sync` for the event that Appkit objects are
+/// added to this type.
 #[non_exhaustive]
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
-pub struct AppKitDisplayHandle {}
+pub struct AppKitDisplayHandle {
+    _thread_unsafe: PhantomData<*mut ()>,
+}
 
 impl AppKitDisplayHandle {
     /// Create a new empty display handle.
@@ -19,7 +30,9 @@ impl AppKitDisplayHandle {
     /// let handle = AppKitDisplayHandle::new();
     /// ```
     pub fn new() -> Self {
-        Self {}
+        Self {
+            _thread_unsafe: PhantomData,
+        }
     }
 }
 
@@ -44,10 +57,6 @@ impl DisplayHandle<'static> {
 }
 
 /// Raw window handle for AppKit.
-///
-/// Note that `NSView` can only be accessed from the main thread of the
-/// application. This struct is `!Send` and `!Sync` to help with ensuring
-/// that.
 ///
 /// # Example
 ///
@@ -83,6 +92,19 @@ impl DisplayHandle<'static> {
 /// }
 /// # }
 /// ```
+///
+/// ## Thread Safety
+///
+/// Handles to AppKit objects can only be safely used from the main thread.
+/// Therefore, all Appkit objects are `!Send` and `!Sync`.
+/// This means that this type cannot be sent to or used from other threads.
+///
+/// In addition, it is also expected that the consumer will take precautions to
+/// ensure that this object is only used on the main thread.
+/// It is recommended to use [`objc2::MainThreadMarker`] as a strategy for
+/// ensuring this.
+///
+/// [`objc2::MainThreadMarker`]: https://docs.rs/objc2/latest/objc2/struct.MainThreadMarker.html
 #[non_exhaustive]
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub struct AppKitWindowHandle {

--- a/src/borrowed.rs
+++ b/src/borrowed.rs
@@ -75,6 +75,11 @@ impl<H: HasDisplayHandle + ?Sized> HasDisplayHandle for alloc::sync::Arc<H> {
 ///
 /// This is the primary return type of the [`HasDisplayHandle`] trait. It is guaranteed to contain
 /// a valid platform-specific display handle for its lifetime.
+///
+/// ## Thread Safety
+///
+/// See individual handle types for thread safety documentation. Since some
+/// window handle types are `!Send` and `!Sync`, this sum type is as well.
 #[repr(transparent)]
 #[derive(PartialEq, Eq, Hash, Copy, Clone)]
 pub struct DisplayHandle<'a> {
@@ -207,6 +212,11 @@ impl<H: HasWindowHandle + ?Sized> HasWindowHandle for alloc::sync::Arc<H> {
 /// trait for more information about these safety requirements.
 ///
 /// This handle is guaranteed to be safe and valid.
+///
+/// ## Thread Safety
+///
+/// See individual handle types for thread safety documentation. Since some
+/// window handle types are `!Send` and `!Sync`, this sum type is as well.
 #[derive(PartialEq, Eq, Hash, Copy, Clone)]
 pub struct WindowHandle<'a> {
     raw: RawWindowHandle,

--- a/src/drm.rs
+++ b/src/drm.rs
@@ -1,4 +1,10 @@
 /// Raw display handle for the Linux Kernel Mode Set/Direct Rendering Manager.
+///
+/// ## Thread Safety
+///
+/// The DRM display handle is a file descriptor, and file descriptors in Unix
+/// are thread-safe by default. Therefore this type is `Send` and `Sync`. This
+/// means that it can be sent to or used from other threads.
 #[non_exhaustive]
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub struct DrmDisplayHandle {
@@ -26,6 +32,12 @@ impl DrmDisplayHandle {
 }
 
 /// Raw window handle for the Linux Kernel Mode Set/Direct Rendering Manager.
+///
+/// ## Thread Safety
+///
+/// DRM "windows" are just planes, which are just numbers. Therefore this type
+/// is `Send` and `Sync`. This means that it can be sent to or used from other
+/// threads.
 #[non_exhaustive]
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub struct DrmWindowHandle {

--- a/src/gbm.rs
+++ b/src/gbm.rs
@@ -2,12 +2,21 @@ use core::ffi::c_void;
 use core::ptr::NonNull;
 
 /// Raw display handle for the Linux Generic Buffer Manager.
+///
+/// ## Thread-Safety
+///
+/// GBM devices are not bound to a single thread; however, they are not
+/// internally secured by mutexes and cannot be used by multiple threads at
+/// once. Therefore this type is `Send` but not `Sync`. This means it can be
+/// sent to other threads but not used from other threads.
 #[non_exhaustive]
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub struct GbmDisplayHandle {
     /// The gbm device.
     pub gbm_device: NonNull<c_void>,
 }
+
+unsafe impl Send for GbmDisplayHandle {}
 
 impl GbmDisplayHandle {
     /// Create a new handle to a device.
@@ -30,12 +39,21 @@ impl GbmDisplayHandle {
 }
 
 /// Raw window handle for the Linux Generic Buffer Manager.
+///
+/// ## Thread-Safety
+///
+/// GBM surfaces are not bound to a single thread; however, they are not
+/// internally secured by mutexes and cannot be used by multiple threads at
+/// once. Therefore this type is `Send` but not `Sync`. This means it can be
+/// sent to other threads but not used from other threads.
 #[non_exhaustive]
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub struct GbmWindowHandle {
     /// The gbm surface.
     pub gbm_surface: NonNull<c_void>,
 }
+
+unsafe impl Send for GbmWindowHandle {}
 
 impl GbmWindowHandle {
     /// Create a new handle to a surface.

--- a/src/haiku.rs
+++ b/src/haiku.rs
@@ -4,6 +4,18 @@ use core::ptr::NonNull;
 use super::DisplayHandle;
 
 /// Raw display handle for Haiku.
+///
+/// ## Thread Safety
+///
+/// Haiku objects are protected by a [global lock]. They are `Send` and `Sync`
+/// as long as producers/downstream consumers take this lock before the `BLooper`
+/// or `BWindow` are used outside of their origin threads.
+///
+/// Note that this type does not currently contain any Haiku objects. However,
+/// it is kept `Send` and `Sync` for the event that Haiku objects are added to
+/// this type.
+///
+/// [global lock]: https://grok.nikisoft.one/opengrok/xref/haiku/src/kits/app/Looper.cpp?r=b47e8b0cadeb9a9d985d7f72d2e9a099cbcb8f90#591-627
 #[non_exhaustive]
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub struct HaikuDisplayHandle {}
@@ -44,6 +56,12 @@ impl DisplayHandle<'static> {
 }
 
 /// Raw window handle for Haiku.
+///
+/// Haiku objects are protected by a [global lock]. They are `Send` and `Sync`
+/// as long as producers/downstream consumers take this lock before the `BLooper`
+/// or `BWindow` are used outside of their origin threads.
+///
+/// [global lock]: https://grok.nikisoft.one/opengrok/xref/haiku/src/kits/app/Looper.cpp?r=b47e8b0cadeb9a9d985d7f72d2e9a099cbcb8f90#591-627
 #[non_exhaustive]
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub struct HaikuWindowHandle {
@@ -52,6 +70,9 @@ pub struct HaikuWindowHandle {
     /// A pointer to a BDirectWindow object that might be null
     pub b_direct_window: Option<NonNull<c_void>>,
 }
+
+unsafe impl Send for HaikuWindowHandle {}
+unsafe impl Sync for HaikuWindowHandle {}
 
 impl HaikuWindowHandle {
     /// Create a new handle to a window.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -90,6 +90,11 @@ use core::fmt;
 /// unexpected. (For example, it's legal for someone to return a
 /// [`RawWindowHandle::Xlib`] on macOS, it would just be weird, and probably
 /// requires something like XQuartz be used).
+///
+/// ## Thread Safety
+///
+/// See individual handle types for thread safety documentation. Since some
+/// window handle types are `!Send` and `!Sync`, this sum type is as well.
 #[non_exhaustive]
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub enum RawWindowHandle {
@@ -212,6 +217,11 @@ pub enum RawWindowHandle {
 /// unexpected. (For example, it's legal for someone to return a
 /// [`RawDisplayHandle::Xlib`] on macOS, it would just be weird, and probably
 /// requires something like XQuartz be used).
+///
+/// ## Thread Safety
+///
+/// See individual handle types for thread safety documentation. Since some
+/// window handle types are `!Send` and `!Sync`, this sum type is as well.
 #[non_exhaustive]
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub enum RawDisplayHandle {
@@ -405,36 +415,40 @@ mod tests {
         assert_impl_all!(HandleError: Send, Sync, UnwindSafe, RefUnwindSafe, Unpin);
 
         // TODO: Unsure if some of these should not actually be Send + Sync
-        assert_impl_all!(UiKitDisplayHandle: Send, Sync);
-        assert_impl_all!(AppKitDisplayHandle: Send, Sync);
+        assert_not_impl_any!(UiKitDisplayHandle: Send, Sync);
+        assert_not_impl_any!(AppKitDisplayHandle: Send, Sync);
         assert_impl_all!(OrbitalDisplayHandle: Send, Sync);
-        assert_impl_all!(OhosDisplayHandle: Send, Sync);
-        assert_not_impl_any!(XlibDisplayHandle: Send, Sync);
-        assert_not_impl_any!(XcbDisplayHandle: Send, Sync);
-        assert_not_impl_any!(WaylandDisplayHandle: Send, Sync);
+        assert_not_impl_any!(OhosDisplayHandle: Send, Sync);
+        assert_impl_all!(XlibDisplayHandle: Send, Sync);
+        assert_impl_all!(XcbDisplayHandle: Send, Sync);
+        assert_impl_all!(WaylandDisplayHandle: Send, Sync);
         assert_impl_all!(DrmDisplayHandle: Send, Sync);
-        assert_not_impl_any!(GbmDisplayHandle: Send, Sync);
+        assert_impl_all!(GbmDisplayHandle: Send);
+        assert_not_impl_any!(GbmDisplayHandle: Sync);
         assert_impl_all!(WindowsDisplayHandle: Send, Sync);
-        assert_impl_all!(WebDisplayHandle: Send, Sync);
+        assert_not_impl_any!(WebDisplayHandle: Send, Sync);
         assert_impl_all!(AndroidDisplayHandle: Send, Sync);
         assert_impl_all!(HaikuDisplayHandle: Send, Sync);
 
         // TODO: Unsure if some of these should not actually be Send + Sync
         assert_not_impl_any!(UiKitWindowHandle: Send, Sync);
         assert_not_impl_any!(AppKitWindowHandle: Send, Sync);
-        assert_not_impl_any!(OrbitalWindowHandle: Send, Sync);
+        assert_impl_all!(OrbitalWindowHandle: Send, Sync);
         assert_not_impl_any!(OhosNdkWindowHandle: Send, Sync);
         assert_impl_all!(XlibWindowHandle: Send, Sync);
         assert_impl_all!(XcbWindowHandle: Send, Sync);
-        assert_not_impl_any!(WaylandWindowHandle: Send, Sync);
+        assert_impl_all!(WaylandWindowHandle: Send, Sync);
         assert_impl_all!(DrmWindowHandle: Send, Sync);
-        assert_not_impl_any!(GbmWindowHandle: Send, Sync);
-        assert_not_impl_any!(Win32WindowHandle: Send, Sync);
-        assert_not_impl_any!(WinRtWindowHandle: Send, Sync);
+        assert_not_impl_any!(GbmWindowHandle: Sync);
+        assert_impl_all!(GbmWindowHandle: Send);
+        assert_not_impl_any!(Win32WindowHandle: Send);
+        assert_not_impl_any!(WinRtWindowHandle: Send);
+        assert_impl_all!(Win32WindowHandle: Sync);
+        assert_impl_all!(WinRtWindowHandle: Sync);
         assert_not_impl_any!(WebCanvasWindowHandle: Send, Sync);
         assert_not_impl_any!(WebOffscreenCanvasWindowHandle: Send, Sync);
-        assert_not_impl_any!(AndroidNdkWindowHandle: Send, Sync);
-        assert_not_impl_any!(HaikuWindowHandle: Send, Sync);
+        assert_impl_all!(AndroidNdkWindowHandle: Send, Sync);
+        assert_impl_all!(HaikuWindowHandle: Send, Sync);
     }
 
     #[allow(unused)]

--- a/src/ohos.rs
+++ b/src/ohos.rs
@@ -15,14 +15,29 @@
 //! [`OHNativeWindow`]: https://gitee.com/openharmony/docs/blob/master/en/application-dev/reference/apis-arkgraphics2d/_native_window.md
 
 use core::ffi::c_void;
+use core::marker::PhantomData;
 use core::ptr::NonNull;
 
 use super::DisplayHandle;
 
 /// Raw display handle for OpenHarmony.
+///
+/// ## Thread-Safety
+///
+/// OpenHarmony [expects] that UI primitives will only be called from one
+/// thread. Therefore, all OHOS objects are `!Send` and `!Sync`. This means
+/// that this type cannot be sent to or used from other threads.
+///
+/// Note that this type does not contain any OHOS objects. However, it is kept
+/// `!Send` and `!Sync` for the event that OHOS objects are added to this
+/// type.
+///
+/// [expects]: https://ai6s.net/6921b48882fbe0098cade00f.html
 #[non_exhaustive]
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
-pub struct OhosDisplayHandle {}
+pub struct OhosDisplayHandle {
+    _thread_unsafe: PhantomData<*mut ()>,
+}
 
 impl OhosDisplayHandle {
     /// Create a new empty display handle.
@@ -35,7 +50,9 @@ impl OhosDisplayHandle {
     /// let handle = OhosDisplayHandle::new();
     /// ```
     pub fn new() -> Self {
-        Self {}
+        Self {
+            _thread_unsafe: PhantomData,
+        }
     }
 }
 
@@ -60,6 +77,14 @@ impl DisplayHandle<'static> {
 }
 
 /// Raw window handle for Ohos NDK.
+///
+/// ## Thread-Safety
+///
+/// OpenHarmony [expects] that UI primitives will only be called from one
+/// thread. Therefore, all OHOS objects are `!Send` and `!Sync`. This means
+/// that this type cannot be sent to or used from other threads.
+///
+/// [expects]: https://ai6s.net/6921b48882fbe0098cade00f.html
 #[non_exhaustive]
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub struct OhosNdkWindowHandle {

--- a/src/redox.rs
+++ b/src/redox.rs
@@ -4,6 +4,19 @@ use core::ptr::NonNull;
 use super::DisplayHandle;
 
 /// Raw display handle for the Redox operating system.
+///
+/// ## Thread Safety
+///
+/// The underlying window is a [file descriptor], and most calls on the window
+/// correspond directly to non-mutating file descriptor reads and writes.
+/// Therefore this type is `Send` and `Sync`. This means that this type can be
+/// sent to and used from other threads.
+///
+/// Note that this type does not currently contain any Orbital file descriptors.
+/// This type is kept as `Send` and `Sync` in preparation for file descriptors
+/// to be added to this type.
+///
+/// [file descriptor]: https://github.com/redox-os/orbclient/blob/77c28e88fcb180c750175f2dcf5c7342d357ab26/src/sys/orbital.rs#L64-L65
 #[non_exhaustive]
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub struct OrbitalDisplayHandle {}
@@ -44,6 +57,15 @@ impl DisplayHandle<'static> {
 }
 
 /// Raw window handle for the Redox operating system.
+///
+/// ## Thread Safety
+///
+/// The underlying window is a [file descriptor], and most calls on the window
+/// correspond directly to non-mutating file descriptor reads and writes.
+/// Therefore this type is `Send` and `Sync`. This means that this type can be
+/// sent to and used from other threads.
+///
+/// [file descriptor]: https://github.com/redox-os/orbclient/blob/77c28e88fcb180c750175f2dcf5c7342d357ab26/src/sys/orbital.rs#L64-L65
 #[non_exhaustive]
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub struct OrbitalWindowHandle {
@@ -52,6 +74,9 @@ pub struct OrbitalWindowHandle {
     // actually use `std::os::fd::RawFd`, or some sort of integer instead?
     pub window: NonNull<c_void>,
 }
+
+unsafe impl Send for OrbitalWindowHandle {}
+unsafe impl Sync for OrbitalWindowHandle {}
 
 impl OrbitalWindowHandle {
     /// Create a new handle to a window.

--- a/src/uikit.rs
+++ b/src/uikit.rs
@@ -1,12 +1,23 @@
 use core::ffi::c_void;
+use core::marker::PhantomData;
 use core::ptr::NonNull;
 
 use super::DisplayHandle;
 
 /// Raw display handle for UIKit.
+///
+/// ## Thread Safety
+///
+/// This type has the same thread safety guarantees as [`UiKitWindowHandle`].
+///
+/// Note that this type does not contain any UiKit objects. However,
+/// it is kept `!Send` and `!Sync` for the event that UiKit objects are
+/// added to this type.
 #[non_exhaustive]
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
-pub struct UiKitDisplayHandle {}
+pub struct UiKitDisplayHandle {
+    _thread_unsafe: PhantomData<*mut ()>,
+}
 
 impl UiKitDisplayHandle {
     /// Create a new empty display handle.
@@ -19,7 +30,9 @@ impl UiKitDisplayHandle {
     /// let handle = UiKitDisplayHandle::new();
     /// ```
     pub fn new() -> Self {
-        Self {}
+        Self {
+            _thread_unsafe: PhantomData,
+        }
     }
 }
 
@@ -44,10 +57,6 @@ impl DisplayHandle<'static> {
 }
 
 /// Raw window handle for UIKit.
-///
-/// Note that `UIView` can only be accessed from the main thread of the
-/// application. This struct is `!Send` and `!Sync` to help with ensuring
-/// that.
 ///
 /// # Example
 ///
@@ -106,6 +115,19 @@ impl DisplayHandle<'static> {
 ///
 /// // Use found_controller here.
 /// ```
+///
+/// ## Thread Safety
+///
+/// Handles to UiKit objects can only be safely used from the main thread.
+/// Therefore, all UiKit objects are `!Send` and `!Sync`.
+/// This means that this type cannot be sent to or used from other threads.
+///
+/// In addition, it is also expected that the consumer will take precautions to
+/// ensure that this object is only used on the main thread.
+/// It is recommended to use [`objc2::MainThreadMarker`] as a strategy for
+/// ensuring this.
+///
+/// [`objc2::MainThreadMarker`]: https://docs.rs/objc2/latest/objc2/struct.MainThreadMarker.html
 #[non_exhaustive]
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub struct UiKitWindowHandle {

--- a/src/wayland.rs
+++ b/src/wayland.rs
@@ -2,12 +2,20 @@ use core::ffi::c_void;
 use core::ptr::NonNull;
 
 /// Raw display handle for Wayland.
+///
+/// ## Thread Safety
+///
+/// `libwayland-client` is thread safe, therefore this type is `Send` and `Sync`.
+/// This means that this type can be sent to and from other threads.
 #[non_exhaustive]
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub struct WaylandDisplayHandle {
     /// A pointer to a `wl_display`.
     pub display: NonNull<c_void>,
 }
+
+unsafe impl Send for WaylandDisplayHandle {}
+unsafe impl Sync for WaylandDisplayHandle {}
 
 impl WaylandDisplayHandle {
     /// Create a new display handle.
@@ -30,12 +38,20 @@ impl WaylandDisplayHandle {
 }
 
 /// Raw window handle for Wayland.
+///
+/// ## Thread Safety
+///
+/// `libwayland-client` is thread safe, therefore this type is `Send` and `Sync`.
+/// This means that this type can be sent to and from other threads.
 #[non_exhaustive]
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub struct WaylandWindowHandle {
     /// A pointer to a `wl_surface`.
     pub surface: NonNull<c_void>,
 }
+
+unsafe impl Send for WaylandWindowHandle {}
+unsafe impl Sync for WaylandWindowHandle {}
 
 impl WaylandWindowHandle {
     /// Create a new handle to a surface.

--- a/src/web.rs
+++ b/src/web.rs
@@ -3,9 +3,25 @@ use core::marker::PhantomData;
 use super::DisplayHandle;
 
 /// Raw display handle for the Web.
+///
+/// ## Thread-Safety
+///
+/// WASM objects are usually bound to the main UI "thread" belonging to the
+/// top-level webpage. Therefore this type is `!Send` and `!Sync`. It cannot be
+/// sent to or used from other threads.
+///
+/// Note that this type does not contain any WASM objects. However,
+/// it is kept `!Send` and `!Sync` for the event that WASM objects are
+/// added to this type.
+///
+/// However, this status quo may change in the future, due to the adoption of
+/// atomics in WASM code. Therefore this type may be made `Send` and `Sync` as
+/// part of a non-breaking change.
 #[non_exhaustive]
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
-pub struct WebDisplayHandle {}
+pub struct WebDisplayHandle {
+    _thread_unsafe: PhantomData<*mut ()>,
+}
 
 impl WebDisplayHandle {
     /// Create a new empty display handle.
@@ -18,7 +34,9 @@ impl WebDisplayHandle {
     /// let handle = WebDisplayHandle::new();
     /// ```
     pub fn new() -> Self {
-        Self {}
+        Self {
+            _thread_unsafe: PhantomData,
+        }
     }
 }
 
@@ -45,6 +63,12 @@ impl DisplayHandle<'static> {
 /// Raw window handle for a Web canvas registered via [`wasm-bindgen`].
 ///
 /// [`wasm-bindgen`]: https://crates.io/crates/wasm-bindgen
+///
+/// ## Thread-Safety
+///
+/// WASM objects are usually bound to the main UI "thread" belonging to the
+/// top-level webpage. Therefore this type is `!Send` and `!Sync`. It cannot be
+/// sent to or used from other threads.
 #[non_exhaustive]
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub struct WebCanvasWindowHandle {
@@ -96,6 +120,12 @@ impl WebCanvasWindowHandle {
 /// [`wasm-bindgen`].
 ///
 /// [`wasm-bindgen`]: https://crates.io/crates/wasm-bindgen
+///
+/// ## Thread-Safety
+///
+/// WASM objects are usually bound to the main UI "thread" belonging to the
+/// top-level webpage. Therefore this type is `!Send` and `!Sync`. It cannot be
+/// sent to or used from other threads.
 #[non_exhaustive]
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub struct WebOffscreenCanvasWindowHandle {

--- a/src/windows.rs
+++ b/src/windows.rs
@@ -6,6 +6,14 @@ use super::DisplayHandle;
 /// Raw display handle for Windows.
 ///
 /// It can be used regardless of Windows window backend.
+///
+/// ## Thread-Safety
+///
+/// Overall, even though Win32 windows have [thread affinity], the overall
+/// Win32 user API is thread-safe. Therefore this type is `Send` and `Sync`.
+/// This means it can be sent to or used from other threads.
+///
+/// [thread affinity]: https://devblogs.microsoft.com/oldnewthing/20051010-09/?p=33843
 #[non_exhaustive]
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub struct WindowsDisplayHandle {}
@@ -46,6 +54,19 @@ impl DisplayHandle<'static> {
 }
 
 /// Raw window handle for Win32.
+///
+/// ## Thread-Safety
+///
+/// Window handles have [thread affinity]. This means that they are `!Send`, as
+/// they must be dropped on the same thread that created them. However, some
+/// functions on the window can be called from other threads. This means that
+/// the window is `Sync`.
+///
+/// Note that not all functions of the Win32 handle are thread-safe (modifying
+/// functions especially), so care should be taken to not call these functions
+/// from other threads. When in doubt, only run the function on the main thread.
+///
+/// [thread affinity]: https://devblogs.microsoft.com/oldnewthing/20051010-09/?p=33843
 #[non_exhaustive]
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub struct Win32WindowHandle {
@@ -54,6 +75,8 @@ pub struct Win32WindowHandle {
     /// The `GWLP_HINSTANCE` associated with this type's `HWND`.
     pub hinstance: Option<NonNull<c_void>>,
 }
+
+unsafe impl Sync for Win32WindowHandle {}
 
 impl Win32WindowHandle {
     /// Create a new handle to a window.
@@ -89,12 +112,27 @@ impl Win32WindowHandle {
 }
 
 /// Raw window handle for WinRT.
+///
+/// ## Thread-Safety
+///
+/// Window handles have [thread affinity]. This means that they are `!Send`, as
+/// they must be dropped on the same thread that created them. However, some
+/// functions on the window can be called from other threads. This means that
+/// the window is `Sync`.
+///
+/// Note that not all functions of the Win32 handle are thread-safe (modifying
+/// functions especially), so care should be taken to not call these functions
+/// from other threads. When in doubt, only run the function on the main thread.
+///
+/// [thread affinity]: https://devblogs.microsoft.com/oldnewthing/20051010-09/?p=33843
 #[non_exhaustive]
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub struct WinRtWindowHandle {
     /// A WinRT `CoreWindow` handle.
     pub core_window: NonNull<c_void>,
 }
+
+unsafe impl Sync for WinRtWindowHandle {}
 
 impl WinRtWindowHandle {
     /// Create a new handle to a window.

--- a/src/x11.rs
+++ b/src/x11.rs
@@ -3,6 +3,14 @@ use core::num::NonZeroU32;
 use core::ptr::NonNull;
 
 /// Raw display handle for Xlib.
+///
+/// ## Thread Safety
+///
+/// Reads and writes to and from the X server are internally secure by a [mutex].
+/// Therefore this type is `Send` and `Sync`. This means it can be sent to or
+/// used from other threads.
+///
+/// [mutex]: https://gitlab.freedesktop.org/xorg/lib/libx11/-/blob/master/src/locking.c?ref_type=heads#L596
 #[non_exhaustive]
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub struct XlibDisplayHandle {
@@ -19,6 +27,9 @@ pub struct XlibDisplayHandle {
     /// given that multiple screens usually reside on different GPUs.
     pub screen: c_int,
 }
+
+unsafe impl Send for XlibDisplayHandle {}
+unsafe impl Sync for XlibDisplayHandle {}
 
 impl XlibDisplayHandle {
     /// Create a new handle to a display.
@@ -43,6 +54,11 @@ impl XlibDisplayHandle {
 }
 
 /// Raw window handle for Xlib.
+///
+/// ## Thread Safety
+///
+/// This type is nothing more than a numeric identifier, therefore it is `Send`
+/// and `Sync`. This means it can be safely sent to or used from other threads.
 #[non_exhaustive]
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub struct XlibWindowHandle {
@@ -54,7 +70,6 @@ pub struct XlibWindowHandle {
 
 impl XlibWindowHandle {
     /// Create a new handle to a window.
-    ///
     ///
     /// # Example
     ///
@@ -77,6 +92,14 @@ impl XlibWindowHandle {
 }
 
 /// Raw display handle for Xcb.
+///
+/// ## Thread Safety
+///
+/// Reads and writes to and from the X server are internally secure by a [mutex].
+/// Therefore this type is `Send` and `Sync`. This means it can be sent to or
+/// used from other threads.
+///
+/// [mutex]: https://gitlab.freedesktop.org/xorg/lib/libxcb/-/blob/master/src/xcb_conn.c?ref_type=heads#L165
 #[non_exhaustive]
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub struct XcbDisplayHandle {
@@ -93,6 +116,9 @@ pub struct XcbDisplayHandle {
     /// given that multiple screens usually reside on different GPUs.
     pub screen: c_int,
 }
+
+unsafe impl Send for XcbDisplayHandle {}
+unsafe impl Sync for XcbDisplayHandle {}
 
 impl XcbDisplayHandle {
     /// Create a new handle to a connection and screen.
@@ -117,6 +143,11 @@ impl XcbDisplayHandle {
 }
 
 /// Raw window handle for Xcb.
+///
+/// ## Thread Safety
+///
+/// This type is nothing more than a numeric identifier, therefore it is `Send`
+/// and `Sync`. This means it can be safely sent to or used from other threads.
 #[non_exhaustive]
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub struct XcbWindowHandle {


### PR DESCRIPTION
In this commit, thread safety documentation is added for all window
handle types. In addition, following some additional research, some
window types have their thread safety changed. Most notably:

- OHOS windows are definitely thread-unsafe.
- Redox and Haiku windows are actually thread safe.
- GBM types are Send but not Sync.
- Win32 windows are Sync but not Send.
- Display handles are changed to match their windows.


