### PR TITLE
Make handle fields private

### DIFF
--- a/src/android.rs
+++ b/src/android.rs
@@ -4,9 +4,8 @@ use core::ptr::NonNull;
 use super::DisplayHandle;
 
 /// Raw display handle for Android.
-#[non_exhaustive]
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
-pub struct AndroidDisplayHandle {}
+pub struct AndroidDisplayHandle(());
 
 impl AndroidDisplayHandle {
     /// Create a new empty display handle.
@@ -19,7 +18,7 @@ impl AndroidDisplayHandle {
     /// let handle = AndroidDisplayHandle::new();
     /// ```
     pub fn new() -> Self {
-        Self {}
+        Self(())
     }
 }
 
@@ -44,16 +43,13 @@ impl DisplayHandle<'static> {
 }
 
 /// Raw window handle for Android NDK.
-#[non_exhaustive]
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub struct AndroidNdkWindowHandle {
-    /// A pointer to an `ANativeWindow`.
-    pub a_native_window: NonNull<c_void>,
+    a_native_window: NonNull<c_void>,
 }
 
 impl AndroidNdkWindowHandle {
     /// Create a new handle to an `ANativeWindow`.
-    ///
     ///
     /// # Example
     ///
@@ -68,5 +64,22 @@ impl AndroidNdkWindowHandle {
     /// ```
     pub fn new(a_native_window: NonNull<c_void>) -> Self {
         Self { a_native_window }
+    }
+
+    /// A pointer to an `ANativeWindow`.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// # use core::ptr::NonNull;
+    /// # use raw_window_handle::AndroidNdkWindowHandle;
+    /// # type ANativeWindow = ();
+    /// #
+    /// # let handle = AndroidNdkWindowHandle::new(NonNull::dangling());
+    /// let ptr = handle.a_native_window();
+    /// let ptr = ptr.cast::<ANativeWindow>();
+    /// ```
+    pub fn a_native_window(&self) -> NonNull<c_void> {
+        self.a_native_window
     }
 }

--- a/src/appkit.rs
+++ b/src/appkit.rs
@@ -4,9 +4,8 @@ use core::ptr::NonNull;
 use super::DisplayHandle;
 
 /// Raw display handle for AppKit.
-#[non_exhaustive]
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
-pub struct AppKitDisplayHandle {}
+pub struct AppKitDisplayHandle(());
 
 impl AppKitDisplayHandle {
     /// Create a new empty display handle.
@@ -19,7 +18,7 @@ impl AppKitDisplayHandle {
     /// let handle = AppKitDisplayHandle::new();
     /// ```
     pub fn new() -> Self {
-        Self {}
+        Self(())
     }
 }
 
@@ -70,7 +69,7 @@ impl DisplayHandle<'static> {
 ///     # #[cfg(requires_objc2)]
 ///     RawWindowHandle::AppKit(handle) => {
 ///         assert!(MainThreadMarker::new().is_some(), "can only access AppKit handles on the main thread");
-///         let ns_view = handle.ns_view.as_ptr();
+///         let ns_view = handle.ns_view().as_ptr();
 ///         // SAFETY: The pointer came from `WindowHandle`, which ensures
 ///         // that the `AppKitWindowHandle` contains a valid pointer to an
 ///         // `NSView`.
@@ -83,11 +82,9 @@ impl DisplayHandle<'static> {
 /// }
 /// # }
 /// ```
-#[non_exhaustive]
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub struct AppKitWindowHandle {
-    /// A pointer to an `NSView` object.
-    pub ns_view: NonNull<c_void>,
+    ns_view: NonNull<c_void>,
 }
 
 impl AppKitWindowHandle {
@@ -111,5 +108,10 @@ impl AppKitWindowHandle {
     /// ```
     pub fn new(ns_view: NonNull<c_void>) -> Self {
         Self { ns_view }
+    }
+
+    /// A pointer to an `NSView` object.
+    pub fn ns_view(&self) -> NonNull<c_void> {
+        self.ns_view
     }
 }

--- a/src/drm.rs
+++ b/src/drm.rs
@@ -1,10 +1,8 @@
 /// Raw display handle for the Linux Kernel Mode Set/Direct Rendering Manager.
-#[non_exhaustive]
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub struct DrmDisplayHandle {
-    /// The drm file descriptor.
     // TODO: Use `std::os::fd::RawFd`?
-    pub fd: i32,
+    fd: i32,
 }
 
 impl DrmDisplayHandle {
@@ -23,14 +21,17 @@ impl DrmDisplayHandle {
     pub fn new(fd: i32) -> Self {
         Self { fd }
     }
+
+    /// The drm file descriptor.
+    pub fn fd(&self) -> i32 {
+        self.fd
+    }
 }
 
 /// Raw window handle for the Linux Kernel Mode Set/Direct Rendering Manager.
-#[non_exhaustive]
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub struct DrmWindowHandle {
-    /// The primary drm plane handle.
-    pub plane: u32,
+    plane: u32,
 }
 
 impl DrmWindowHandle {
@@ -48,5 +49,10 @@ impl DrmWindowHandle {
     /// ```
     pub fn new(plane: u32) -> Self {
         Self { plane }
+    }
+
+    /// The primary drm plane handle.
+    pub fn plane(&self) -> u32 {
+        self.plane
     }
 }

--- a/src/gbm.rs
+++ b/src/gbm.rs
@@ -2,11 +2,9 @@ use core::ffi::c_void;
 use core::ptr::NonNull;
 
 /// Raw display handle for the Linux Generic Buffer Manager.
-#[non_exhaustive]
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub struct GbmDisplayHandle {
-    /// The gbm device.
-    pub gbm_device: NonNull<c_void>,
+    gbm_device: NonNull<c_void>,
 }
 
 impl GbmDisplayHandle {
@@ -27,14 +25,17 @@ impl GbmDisplayHandle {
     pub fn new(gbm_device: NonNull<c_void>) -> Self {
         Self { gbm_device }
     }
+
+    /// The gbm device.
+    pub fn gbm_device(&self) -> NonNull<c_void> {
+        self.gbm_device
+    }
 }
 
 /// Raw window handle for the Linux Generic Buffer Manager.
-#[non_exhaustive]
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub struct GbmWindowHandle {
-    /// The gbm surface.
-    pub gbm_surface: NonNull<c_void>,
+    gbm_surface: NonNull<c_void>,
 }
 
 impl GbmWindowHandle {
@@ -54,5 +55,10 @@ impl GbmWindowHandle {
     /// ```
     pub fn new(gbm_surface: NonNull<c_void>) -> Self {
         Self { gbm_surface }
+    }
+
+    /// The gbm surface.
+    pub fn gbm_surface(&self) -> NonNull<c_void> {
+        self.gbm_surface
     }
 }

--- a/src/haiku.rs
+++ b/src/haiku.rs
@@ -4,9 +4,8 @@ use core::ptr::NonNull;
 use super::DisplayHandle;
 
 /// Raw display handle for Haiku.
-#[non_exhaustive]
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
-pub struct HaikuDisplayHandle {}
+pub struct HaikuDisplayHandle(());
 
 impl HaikuDisplayHandle {
     /// Create a new empty display handle.
@@ -19,7 +18,7 @@ impl HaikuDisplayHandle {
     /// let handle = HaikuDisplayHandle::new();
     /// ```
     pub fn new() -> Self {
-        Self {}
+        Self(())
     }
 }
 
@@ -44,18 +43,14 @@ impl DisplayHandle<'static> {
 }
 
 /// Raw window handle for Haiku.
-#[non_exhaustive]
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub struct HaikuWindowHandle {
-    /// A pointer to a BWindow object
-    pub b_window: NonNull<c_void>,
-    /// A pointer to a BDirectWindow object that might be null
-    pub b_direct_window: Option<NonNull<c_void>>,
+    b_window: NonNull<c_void>,
+    b_direct_window: Option<NonNull<c_void>>,
 }
 
 impl HaikuWindowHandle {
     /// Create a new handle to a window.
-    ///
     ///
     /// # Example
     ///
@@ -66,14 +61,45 @@ impl HaikuWindowHandle {
     /// #
     /// let b_window: NonNull<BWindow>;
     /// # b_window = NonNull::from(&());
-    /// let mut handle = HaikuWindowHandle::new(b_window.cast());
-    /// // Optionally set `b_direct_window`.
-    /// handle.b_direct_window = None;
+    /// let handle = HaikuWindowHandle::new(b_window.cast());
     /// ```
     pub fn new(b_window: NonNull<c_void>) -> Self {
         Self {
             b_window,
             b_direct_window: None,
         }
+    }
+
+    /// Create a new window handle together with a `BDirectWindow`.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// # use core::ptr::NonNull;
+    /// # use raw_window_handle::HaikuWindowHandle;
+    /// # type BWindow = ();
+    /// # type BDirectWindow = ();
+    /// #
+    /// let b_window: NonNull<BWindow>;
+    /// let b_direct_window: NonNull<BDirectWindow>;
+    /// # b_window = NonNull::dangling();
+    /// # b_direct_window = NonNull::dangling();
+    /// let handle = HaikuWindowHandle::with_window(b_window.cast(), b_direct_window.cast());
+    /// ```
+    pub fn with_window(b_window: NonNull<c_void>, b_direct_window: NonNull<c_void>) -> Self {
+        Self {
+            b_window,
+            b_direct_window: Some(b_direct_window),
+        }
+    }
+
+    /// A pointer to a BWindow object.
+    pub fn b_window(&self) -> NonNull<c_void> {
+        self.b_window
+    }
+
+    /// A pointer to a BDirectWindow object that might be null.
+    pub fn b_direct_window(&self) -> Option<NonNull<c_void>> {
+        self.b_direct_window
     }
 }

--- a/src/ohos.rs
+++ b/src/ohos.rs
@@ -20,9 +20,8 @@ use core::ptr::NonNull;
 use super::DisplayHandle;
 
 /// Raw display handle for OpenHarmony.
-#[non_exhaustive]
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
-pub struct OhosDisplayHandle {}
+pub struct OhosDisplayHandle(());
 
 impl OhosDisplayHandle {
     /// Create a new empty display handle.
@@ -35,7 +34,7 @@ impl OhosDisplayHandle {
     /// let handle = OhosDisplayHandle::new();
     /// ```
     pub fn new() -> Self {
-        Self {}
+        Self(())
     }
 }
 
@@ -60,10 +59,9 @@ impl DisplayHandle<'static> {
 }
 
 /// Raw window handle for Ohos NDK.
-#[non_exhaustive]
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub struct OhosNdkWindowHandle {
-    pub native_window: NonNull<c_void>,
+    native_window: NonNull<c_void>,
 }
 
 impl OhosNdkWindowHandle {
@@ -94,5 +92,10 @@ impl OhosNdkWindowHandle {
     /// ```
     pub fn new(native_window: NonNull<c_void>) -> Self {
         Self { native_window }
+    }
+
+    /// Get the handle to `OHNativeWindow`.
+    pub fn native_window(&self) -> NonNull<c_void> {
+        self.native_window
     }
 }

--- a/src/redox.rs
+++ b/src/redox.rs
@@ -4,9 +4,8 @@ use core::ptr::NonNull;
 use super::DisplayHandle;
 
 /// Raw display handle for the Redox operating system.
-#[non_exhaustive]
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
-pub struct OrbitalDisplayHandle {}
+pub struct OrbitalDisplayHandle(());
 
 impl OrbitalDisplayHandle {
     /// Create a new empty display handle.
@@ -19,7 +18,7 @@ impl OrbitalDisplayHandle {
     /// let handle = OrbitalDisplayHandle::new();
     /// ```
     pub fn new() -> Self {
-        Self {}
+        Self(())
     }
 }
 
@@ -44,13 +43,11 @@ impl DisplayHandle<'static> {
 }
 
 /// Raw window handle for the Redox operating system.
-#[non_exhaustive]
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub struct OrbitalWindowHandle {
-    /// A pointer to an orbclient window.
     // TODO(madsmtm): I think this is a file descriptor, so perhaps it should
     // actually use `std::os::fd::RawFd`, or some sort of integer instead?
-    pub window: NonNull<c_void>,
+    window: NonNull<c_void>,
 }
 
 impl OrbitalWindowHandle {
@@ -70,5 +67,10 @@ impl OrbitalWindowHandle {
     /// ```
     pub fn new(window: NonNull<c_void>) -> Self {
         Self { window }
+    }
+
+    /// A pointer to an orbclient window.
+    pub fn window(&self) -> NonNull<c_void> {
+        self.window
     }
 }

--- a/src/uikit.rs
+++ b/src/uikit.rs
@@ -4,9 +4,8 @@ use core::ptr::NonNull;
 use super::DisplayHandle;
 
 /// Raw display handle for UIKit.
-#[non_exhaustive]
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
-pub struct UiKitDisplayHandle {}
+pub struct UiKitDisplayHandle(());
 
 impl UiKitDisplayHandle {
     /// Create a new empty display handle.
@@ -19,7 +18,7 @@ impl UiKitDisplayHandle {
     /// let handle = UiKitDisplayHandle::new();
     /// ```
     pub fn new() -> Self {
-        Self {}
+        Self(())
     }
 }
 
@@ -70,7 +69,7 @@ impl DisplayHandle<'static> {
 ///     # #[cfg(requires_objc2)]
 ///     RawWindowHandle::UIKit(handle) => {
 ///         assert!(MainThreadMarker::new().is_some(), "can only access UIKit handles on the main thread");
-///         let ui_view = handle.ui_view.as_ptr();
+///         let ui_view = handle.ui_view().as_ptr();
 ///         // SAFETY: The pointer came from `WindowHandle`, which ensures
 ///         // that the `UiKitWindowHandle` contains a valid pointer to an
 ///         // `UIView`.
@@ -106,11 +105,9 @@ impl DisplayHandle<'static> {
 ///
 /// // Use found_controller here.
 /// ```
-#[non_exhaustive]
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub struct UiKitWindowHandle {
-    /// A pointer to an `UIView` object.
-    pub ui_view: NonNull<c_void>,
+    ui_view: NonNull<c_void>,
 }
 
 impl UiKitWindowHandle {
@@ -133,5 +130,10 @@ impl UiKitWindowHandle {
     /// ```
     pub fn new(ui_view: NonNull<c_void>) -> Self {
         Self { ui_view }
+    }
+
+    /// A pointer to an `UIView` object.
+    pub fn ui_view(&self) -> NonNull<c_void> {
+        self.ui_view
     }
 }

--- a/src/wayland.rs
+++ b/src/wayland.rs
@@ -2,11 +2,9 @@ use core::ffi::c_void;
 use core::ptr::NonNull;
 
 /// Raw display handle for Wayland.
-#[non_exhaustive]
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub struct WaylandDisplayHandle {
-    /// A pointer to a `wl_display`.
-    pub display: NonNull<c_void>,
+    display: NonNull<c_void>,
 }
 
 impl WaylandDisplayHandle {
@@ -27,14 +25,17 @@ impl WaylandDisplayHandle {
     pub fn new(display: NonNull<c_void>) -> Self {
         Self { display }
     }
+
+    /// A pointer to a `wl_display`.
+    pub fn display(&self) -> NonNull<c_void> {
+        self.display
+    }
 }
 
 /// Raw window handle for Wayland.
-#[non_exhaustive]
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub struct WaylandWindowHandle {
-    /// A pointer to a `wl_surface`.
-    pub surface: NonNull<c_void>,
+    surface: NonNull<c_void>,
 }
 
 impl WaylandWindowHandle {
@@ -54,5 +55,10 @@ impl WaylandWindowHandle {
     /// ```
     pub fn new(surface: NonNull<c_void>) -> Self {
         Self { surface }
+    }
+
+    /// A pointer to a `wl_surface`.
+    pub fn surface(&self) -> NonNull<c_void> {
+        self.surface
     }
 }

--- a/src/web.rs
+++ b/src/web.rs
@@ -3,9 +3,8 @@ use core::marker::PhantomData;
 use super::DisplayHandle;
 
 /// Raw display handle for the Web.
-#[non_exhaustive]
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
-pub struct WebDisplayHandle {}
+pub struct WebDisplayHandle(());
 
 impl WebDisplayHandle {
     /// Create a new empty display handle.
@@ -18,7 +17,7 @@ impl WebDisplayHandle {
     /// let handle = WebDisplayHandle::new();
     /// ```
     pub fn new() -> Self {
-        Self {}
+        Self(())
     }
 }
 
@@ -45,14 +44,9 @@ impl DisplayHandle<'static> {
 /// Raw window handle for a Web canvas registered via [`wasm-bindgen`].
 ///
 /// [`wasm-bindgen`]: https://crates.io/crates/wasm-bindgen
-#[non_exhaustive]
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub struct WebCanvasWindowHandle {
-    /// An inner index of the [`JsValue`] of an [`HtmlCanvasElement`].
-    ///
-    /// [`JsValue`]: https://docs.rs/wasm-bindgen/latest/wasm_bindgen/struct.JsValue.html
-    /// [`HtmlCanvasElement`]: https://docs.rs/web-sys/latest/web_sys/struct.HtmlCanvasElement.html
-    pub obj: usize,
+    obj: usize,
 
     /// Makes this type `!Send` and `!Sync`.
     _marker: PhantomData<*mut ()>,
@@ -81,7 +75,7 @@ impl WebCanvasWindowHandle {
     ///
     /// // To get the canvas element back, convert the index back.
     /// let other_end: ManuallyDrop<HtmlCanvasElement> = unsafe {
-    ///     HtmlCanvasElement::ref_from_abi(handle.obj as u32)
+    ///     HtmlCanvasElement::ref_from_abi(handle.obj() as u32)
     /// };
     /// ```
     pub fn new(obj: usize) -> Self {
@@ -90,20 +84,23 @@ impl WebCanvasWindowHandle {
             _marker: PhantomData,
         }
     }
+
+    /// An inner index of the [`JsValue`] of an [`HtmlCanvasElement`].
+    ///
+    /// [`JsValue`]: https://docs.rs/wasm-bindgen/latest/wasm_bindgen/struct.JsValue.html
+    /// [`HtmlCanvasElement`]: https://docs.rs/web-sys/latest/web_sys/struct.HtmlCanvasElement.html
+    pub fn obj(&self) -> usize {
+        self.obj
+    }
 }
 
 /// Raw window handle for a Web offscreen canvas registered via
 /// [`wasm-bindgen`].
 ///
 /// [`wasm-bindgen`]: https://crates.io/crates/wasm-bindgen
-#[non_exhaustive]
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub struct WebOffscreenCanvasWindowHandle {
-    /// An inner index of the [`JsValue`] of an [`OffscreenCanvas`].
-    ///
-    /// [`JsValue`]: https://docs.rs/wasm-bindgen/latest/wasm_bindgen/struct.JsValue.html
-    /// [`OffscreenCanvas`]: https://docs.rs/web-sys/latest/web_sys/struct.OffscreenCanvas.html
-    pub obj: usize,
+    obj: usize,
 
     /// Makes this type `!Send` and `!Sync`.
     _marker: PhantomData<*mut ()>,
@@ -132,7 +129,7 @@ impl WebOffscreenCanvasWindowHandle {
     ///
     /// // To get the canvas element back, convert the index back.
     /// let other_end: ManuallyDrop<OffscreenCanvas> = unsafe {
-    ///     OffscreenCanvas::ref_from_abi(handle.obj as u32)
+    ///     OffscreenCanvas::ref_from_abi(handle.obj() as u32)
     /// };
     /// ```
     pub fn new(obj: usize) -> Self {
@@ -140,5 +137,13 @@ impl WebOffscreenCanvasWindowHandle {
             obj,
             _marker: PhantomData,
         }
+    }
+
+    /// An inner index of the [`JsValue`] of an [`OffscreenCanvas`].
+    ///
+    /// [`JsValue`]: https://docs.rs/wasm-bindgen/latest/wasm_bindgen/struct.JsValue.html
+    /// [`OffscreenCanvas`]: https://docs.rs/web-sys/latest/web_sys/struct.OffscreenCanvas.html
+    pub fn obj(&self) -> usize {
+        self.obj
     }
 }

--- a/src/windows.rs
+++ b/src/windows.rs
@@ -6,9 +6,8 @@ use super::DisplayHandle;
 /// Raw display handle for Windows.
 ///
 /// It can be used regardless of Windows window backend.
-#[non_exhaustive]
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
-pub struct WindowsDisplayHandle {}
+pub struct WindowsDisplayHandle(());
 
 impl WindowsDisplayHandle {
     /// Create a new empty display handle.
@@ -21,7 +20,7 @@ impl WindowsDisplayHandle {
     /// let handle = WindowsDisplayHandle::new();
     /// ```
     pub fn new() -> Self {
-        Self {}
+        Self(())
     }
 }
 
@@ -46,13 +45,10 @@ impl DisplayHandle<'static> {
 }
 
 /// Raw window handle for Win32.
-#[non_exhaustive]
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub struct Win32WindowHandle {
-    /// A Win32 `HWND` handle.
-    pub hwnd: NonNull<c_void>,
-    /// The `GWLP_HINSTANCE` associated with this type's `HWND`.
-    pub hinstance: Option<NonNull<c_void>>,
+    hwnd: NonNull<c_void>,
+    hinstance: Option<NonNull<c_void>>,
 }
 
 impl Win32WindowHandle {
@@ -73,12 +69,7 @@ impl Win32WindowHandle {
     /// #
     /// let window: HWND;
     /// # window = HWND(1 as *mut c_void);
-    /// let mut handle = Win32WindowHandle::new(NonNull::new(window.0).unwrap());
-    /// // Optionally set the GWLP_HINSTANCE.
-    /// # #[cfg(only_for_showcase)]
-    /// let hinstance = NonNull::new(unsafe { GetWindowLongPtrW(window, GWLP_HINSTANCE) }).unwrap();
-    /// # let hinstance = None;
-    /// handle.hinstance = hinstance;
+    /// let handle = Win32WindowHandle::new(NonNull::new(window.0).unwrap());
     /// ```
     pub fn new(hwnd: NonNull<c_void>) -> Self {
         Self {
@@ -86,14 +77,46 @@ impl Win32WindowHandle {
             hinstance: None,
         }
     }
+
+    /// Create a new window handle to a window together with its `GWLP_HINSTANCE`.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// # use core::ffi::c_void;
+    /// # use core::ptr::NonNull;
+    /// # use raw_window_handle::Win32WindowHandle;
+    /// # struct HWND(*mut c_void);
+    /// #
+    /// let window: HWND;
+    /// # window = HWND(1 as *mut c_void);
+    /// # #[cfg(only_for_showcase)]
+    /// let hinstance = NonNull::new(unsafe { GetWindowLongPtrW(window, GWLP_HINSTANCE) }).unwrap();
+    /// # let hinstance = NonNull::dangling();
+    /// let handle = Win32WindowHandle::with_hinstance(NonNull::new(window.0).unwrap(), hinstance);
+    /// ```
+    pub fn with_hinstance(hwnd: NonNull<c_void>, hinstance: NonNull<c_void>) -> Self {
+        Self {
+            hwnd,
+            hinstance: Some(hinstance),
+        }
+    }
+
+    /// A Win32 `HWND` handle.
+    pub fn hwnd(&self) -> NonNull<c_void> {
+        self.hwnd
+    }
+
+    /// The `GWLP_HINSTANCE` associated with this type's `HWND`.
+    pub fn hinstance(&self) -> Option<NonNull<c_void>> {
+        self.hinstance
+    }
 }
 
 /// Raw window handle for WinRT.
-#[non_exhaustive]
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub struct WinRtWindowHandle {
-    /// A WinRT `CoreWindow` handle.
-    pub core_window: NonNull<c_void>,
+    core_window: NonNull<c_void>,
 }
 
 impl WinRtWindowHandle {
@@ -113,5 +136,10 @@ impl WinRtWindowHandle {
     /// ```
     pub fn new(core_window: NonNull<c_void>) -> Self {
         Self { core_window }
+    }
+
+    /// A WinRT `CoreWindow` handle.
+    pub fn core_window(&self) -> NonNull<c_void> {
+        self.core_window
     }
 }

--- a/src/x11.rs
+++ b/src/x11.rs
@@ -3,21 +3,10 @@ use core::num::NonZeroU32;
 use core::ptr::NonNull;
 
 /// Raw display handle for Xlib.
-#[non_exhaustive]
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub struct XlibDisplayHandle {
-    /// A pointer to an Xlib `Display`.
-    ///
-    /// It is strongly recommended to set this value, however it may be set to
-    /// `None` to request the default display when using EGL.
-    pub display: Option<NonNull<c_void>>,
-
-    /// An X11 screen to use with this display handle.
-    ///
-    /// Note, that X11 could have multiple screens, however
-    /// graphics APIs could work only with one screen at the time,
-    /// given that multiple screens usually reside on different GPUs.
-    pub screen: c_int,
+    display: Option<NonNull<c_void>>,
+    screen: c_int,
 }
 
 impl XlibDisplayHandle {
@@ -35,21 +24,50 @@ impl XlibDisplayHandle {
     /// let screen;
     /// # display = NonNull::from(&()).cast();
     /// # screen = 0;
-    /// let handle = XlibDisplayHandle::new(Some(display), screen);
+    /// let handle = XlibDisplayHandle::new(display, screen);
     /// ```
-    pub fn new(display: Option<NonNull<c_void>>, screen: c_int) -> Self {
-        Self { display, screen }
+    pub fn new(display: NonNull<c_void>, screen: c_int) -> Self {
+        Self {
+            display: Some(display),
+            screen,
+        }
+    }
+
+    /// Create a new handle to a screen with the default display.
+    ///
+    /// You are strongly encouraged to call [`XcbDisplayHandle::new`] when possible.
+    pub fn with_default_display(screen: c_int) -> Self {
+        Self {
+            display: None,
+            screen,
+        }
+    }
+
+    /// A pointer to an Xlib `Display`.
+    ///
+    /// It is strongly recommended to set this value, however it may be set to
+    /// `None` to request the default display when using EGL.
+    pub fn display(&self) -> Option<NonNull<c_void>> {
+        self.display
+    }
+
+    /// An X11 screen to use with this display handle.
+    ///
+    /// Note, that X11 could have multiple screens, however
+    /// graphics APIs could work only with one screen at the time,
+    /// given that multiple screens usually reside on different GPUs.
+    pub fn screen(&self) -> c_int {
+        self.screen
     }
 }
 
 /// Raw window handle for Xlib.
-#[non_exhaustive]
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub struct XlibWindowHandle {
-    /// An Xlib `Window`.
-    pub window: c_ulong,
-    /// An Xlib visual ID, or 0 if unknown.
-    pub visual_id: c_ulong,
+    // TODO(MSRV 1.79): Use `NonZero<c_ulong>`?
+    window: c_ulong,
+    // TODO(MSRV 1.79): Use `Option<NonZero<c_ulong>>`?
+    visual_id: c_ulong,
 }
 
 impl XlibWindowHandle {
@@ -64,9 +82,7 @@ impl XlibWindowHandle {
     /// #
     /// let window: c_ulong;
     /// # window = 0;
-    /// let mut handle = XlibWindowHandle::new(window);
-    /// // Optionally set the visual ID.
-    /// handle.visual_id = 0;
+    /// let handle = XlibWindowHandle::new(window);
     /// ```
     pub fn new(window: c_ulong) -> Self {
         Self {
@@ -74,24 +90,42 @@ impl XlibWindowHandle {
             visual_id: 0,
         }
     }
+
+    /// Create a new handle to a window along with a visual ID.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// # use core::ffi::c_ulong;
+    /// # use raw_window_handle::XlibWindowHandle;
+    /// #
+    /// let window: c_ulong;
+    /// let visual_id: c_ulong;
+    /// # window = 1;
+    /// # visual_id = 1;
+    /// let handle = XlibWindowHandle::with_visual_id(window, visual_id);
+    /// ```
+    pub fn with_visual_id(window: c_ulong, visual_id: c_ulong) -> Self {
+        assert_ne!(visual_id, 0); // TODO: Should we have this check?
+        Self { window, visual_id }
+    }
+
+    /// An Xlib `Window`.
+    pub fn window(&self) -> c_ulong {
+        self.window
+    }
+
+    /// An Xlib visual ID, or 0 if unknown.
+    pub fn visual_id(&self) -> c_ulong {
+        self.visual_id
+    }
 }
 
 /// Raw display handle for Xcb.
-#[non_exhaustive]
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub struct XcbDisplayHandle {
-    /// A pointer to an X server `xcb_connection_t`.
-    ///
-    /// It is strongly recommended to set this value, however it may be set to
-    /// `None` to request the default display when using EGL.
-    pub connection: Option<NonNull<c_void>>,
-
-    /// An X11 screen to use with this display handle.
-    ///
-    /// Note, that X11 could have multiple screens, however
-    /// graphics APIs could work only with one screen at the time,
-    /// given that multiple screens usually reside on different GPUs.
-    pub screen: c_int,
+    connection: Option<NonNull<c_void>>,
+    screen: c_int,
 }
 
 impl XcbDisplayHandle {
@@ -109,21 +143,48 @@ impl XcbDisplayHandle {
     /// let screen;
     /// # connection = NonNull::from(&()).cast();
     /// # screen = 0;
-    /// let handle = XcbDisplayHandle::new(Some(connection), screen);
+    /// let handle = XcbDisplayHandle::new(connection, screen);
     /// ```
-    pub fn new(connection: Option<NonNull<c_void>>, screen: c_int) -> Self {
-        Self { connection, screen }
+    pub fn new(connection: NonNull<c_void>, screen: c_int) -> Self {
+        Self {
+            connection: Some(connection),
+            screen,
+        }
+    }
+
+    /// Create a new handle to a screen with the default connection.
+    ///
+    /// You are strongly encouraged to call [`XcbDisplayHandle::new`] when possible.
+    pub fn with_default_connection(screen: c_int) -> Self {
+        Self {
+            connection: None,
+            screen,
+        }
+    }
+
+    /// A pointer to an X server `xcb_connection_t`.
+    ///
+    /// It is strongly recommended that producers set this value, however it may be set to
+    /// `None` to request the default display when using EGL.
+    pub fn connection(&self) -> Option<NonNull<c_void>> {
+        self.connection
+    }
+
+    /// An X11 screen to use with this display handle.
+    ///
+    /// Note, that X11 could have multiple screens, however
+    /// graphics APIs could work only with one screen at the time,
+    /// given that multiple screens usually reside on different GPUs.
+    pub fn screen(&self) -> c_int {
+        self.screen
     }
 }
 
 /// Raw window handle for Xcb.
-#[non_exhaustive]
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub struct XcbWindowHandle {
-    /// An X11 `xcb_window_t`.
-    pub window: NonZeroU32, // Based on xproto.h
-    /// An X11 `xcb_visualid_t`.
-    pub visual_id: Option<NonZeroU32>,
+    window: NonZeroU32, // Based on xproto.h
+    visual_id: Option<NonZeroU32>,
 }
 
 impl XcbWindowHandle {
@@ -138,14 +199,43 @@ impl XcbWindowHandle {
     /// #
     /// let window: NonZeroU32;
     /// # window = NonZeroU32::new(1).unwrap();
-    /// let mut handle = XcbWindowHandle::new(window);
-    /// // Optionally set the visual ID.
-    /// handle.visual_id = None;
+    /// let handle = XcbWindowHandle::new(window);
     /// ```
     pub fn new(window: NonZeroU32) -> Self {
         Self {
             window,
             visual_id: None,
         }
+    }
+
+    /// Create a new handle to a window along with a `xcb_visualid_t`.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// # use core::num::NonZeroU32;
+    /// # use raw_window_handle::XcbWindowHandle;
+    /// #
+    /// let window: NonZeroU32;
+    /// let visual_id: NonZeroU32;
+    /// # window = NonZeroU32::new(1).unwrap();
+    /// # visual_id = NonZeroU32::new(1).unwrap();
+    /// let handle = XcbWindowHandle::with_visual_id(window, visual_id);
+    /// ```
+    pub fn with_visual_id(window: NonZeroU32, visual_id: NonZeroU32) -> Self {
+        Self {
+            window,
+            visual_id: Some(visual_id),
+        }
+    }
+
+    /// An X11 `xcb_window_t`.
+    pub fn window(&self) -> NonZeroU32 {
+        self.window
+    }
+
+    /// An X11 `xcb_visualid_t`.
+    pub fn visual_id(&self) -> Option<NonZeroU32> {
+        self.visual_id
     }
 }

--- a/tests/web_handles.rs
+++ b/tests/web_handles.rs
@@ -27,7 +27,7 @@ fn html_canvas_element() {
 
     // To get the canvas element back, convert the index back.
     let other_end: ManuallyDrop<HtmlCanvasElement> =
-        unsafe { HtmlCanvasElement::ref_from_abi(handle.obj as u32) };
+        unsafe { HtmlCanvasElement::ref_from_abi(handle.obj() as u32) };
     assert_eq!(&*other_end, &canvas);
 }
 
@@ -42,7 +42,7 @@ fn offscreen_canvas() {
 
     // To get the canvas element back, convert the index back.
     let other_end: ManuallyDrop<OffscreenCanvas> =
-        unsafe { OffscreenCanvas::ref_from_abi(handle.obj as u32) };
+        unsafe { OffscreenCanvas::ref_from_abi(handle.obj() as u32) };
     assert_eq!(&*other_end, &canvas);
 }
 


### PR DESCRIPTION
This allows platform-specific handle structs to define additional safety invariants (which would otherwise be trivial to override by modifying the field).

This unblocks doing either of:
- Adding reference-counting to platform handles, as I propose in https://github.com/rust-windowing/raw-window-handle/issues/188#issuecomment-3976394170.
- Combining `WindowHandle<'_>` and `RawWindowHandle`, see https://github.com/rust-windowing/raw-window-handle/issues/178.