### PR TITLE
Remove `UiKitWindowHandle::ui_view_controller`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,8 +5,8 @@
 * **Breaking:** Rework web handles to remove `wasm-bindgen` from public API. (#184)
 - **Breaking:** Remove `WebWindowHandle` as it is no longer used. (#186)
 - **Breaking:** Remove deprecated `HasRawWindowHandle` and `HasRawDisplayHandle` traits.
+- **Breaking:** Remove `UiKitWindowHandle::ui_view_controller` field, retrieve this from the UIView's responder chain instead.
 * Improve documentation on AppKit and UIKit handles.
-* Deprecated `UiKitWindowHandle::ui_view_controller`, retrieve this from the UIView's responder chain instead.
 
 ## 0.6.2 (2024-05-17)
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -427,6 +427,6 @@ mod tests {
         assert_not_impl_any!(HaikuWindowHandle: Send, Sync);
     }
 
-    #[allow(deprecated, unused)]
+    #[allow(unused)]
     fn assert_object_safe(_: &dyn HasWindowHandle, _: &dyn HasDisplayHandle) {}
 }

--- a/src/uikit.rs
+++ b/src/uikit.rs
@@ -82,39 +82,35 @@ impl DisplayHandle<'static> {
 /// }
 /// # }
 /// ```
+///
+/// Get a pointer to an `UIViewController` object by traversing the `UIView`'s responder chain:
+///
+/// ```ignore
+/// use objc2::rc::Retained;
+/// use objc2_ui_kit::{UIResponder, UIView, UIViewController};
+///
+/// let view: Retained<UIView> = ...;
+///
+/// let mut current_responder: Retained<UIResponder> = view.into_super();
+/// let mut found_controller = None;
+/// while let Some(responder) = unsafe { current_responder.nextResponder() } {
+///     match responder.downcast::<UIViewController>() {
+///         Ok(controller) => {
+///             found_controller = Some(controller);
+///             break;
+///         }
+///         // Search next.
+///         Err(responder) => current_responder = responder,
+///     }
+/// }
+///
+/// // Use found_controller here.
+/// ```
 #[non_exhaustive]
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub struct UiKitWindowHandle {
     /// A pointer to an `UIView` object.
     pub ui_view: NonNull<c_void>,
-    /// A pointer to an `UIViewController` object, if the view has one.
-    ///
-    /// This is deprecated, the controller should be retrieved by traversing the `UIView`'s\
-    /// responder chain instead:
-    ///
-    /// ```ignore
-    /// use objc2::rc::Retained;
-    /// use objc2_ui_kit::{UIResponder, UIView, UIViewController};
-    ///
-    /// let view: Retained<UIView> = ...;
-    ///
-    /// let mut current_responder: Retained<UIResponder> = view.into_super();
-    /// let mut found_controller = None;
-    /// while let Some(responder) = unsafe { current_responder.nextResponder() } {
-    ///     match responder.downcast::<UIViewController>() {
-    ///         Ok(controller) => {
-    ///             found_controller = Some(controller);
-    ///             break;
-    ///         }
-    ///         // Search next.
-    ///         Err(responder) => current_responder = responder,
-    ///     }
-    /// }
-    ///
-    /// // Use found_controller here.
-    /// ```
-    #[deprecated = "retrieve the view controller from the UIView's responder chain instead"]
-    pub ui_view_controller: Option<NonNull<c_void>>,
 }
 
 impl UiKitWindowHandle {
@@ -136,10 +132,6 @@ impl UiKitWindowHandle {
     /// let handle = UiKitWindowHandle::new(ui_view.cast());
     /// ```
     pub fn new(ui_view: NonNull<c_void>) -> Self {
-        #[allow(deprecated)]
-        Self {
-            ui_view,
-            ui_view_controller: None,
-        }
+        Self { ui_view }
     }
 }


### PR DESCRIPTION
Turns out I never released `v0.6.3` with this deprecated, which is unfortunate, but oh well.