### PR TITLE
Rename `DisplayHandle::web` -> `DisplayHandle::wasm_bindgen`

### DIFF
--- a/src/web.rs
+++ b/src/web.rs
@@ -41,7 +41,7 @@ impl WasmBindgenDisplay {
 }
 
 impl DisplayHandle<'static> {
-    /// Create a Web-based display handle.
+    /// Create a `wasm-bindgen`-based display handle.
     ///
     /// As no data is borrowed by this handle, it is completely safe to create. This function
     /// may be useful to windowing framework implementations that want to avoid unsafe code.
@@ -51,10 +51,10 @@ impl DisplayHandle<'static> {
     /// ```
     /// # use raw_window_handle::{DisplayHandle, HasDisplayHandle};
     /// # fn do_something(rwh: impl HasDisplayHandle) { let _ = rwh; }
-    /// let handle = DisplayHandle::web();
+    /// let handle = DisplayHandle::wasm_bindgen();
     /// do_something(handle);
     /// ```
-    pub fn web() -> Self {
+    pub fn wasm_bindgen() -> Self {
         // SAFETY: No data is borrowed.
         unsafe { Self::borrow_raw(WasmBindgenDisplay::new().into()) }
     }


### PR DESCRIPTION
Small oversight from https://github.com/rust-windowing/raw-window-handle/pull/205.