### PR TITLE
Rename `DisplayHandle` convenience methods

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - **Breaking:** Remove deprecated `HasRawWindowHandle` and `HasRawDisplayHandle` traits.
 - **Breaking:** Remove `UiKitWindowHandle::ui_view_controller` field, retrieve this from the UIView's responder chain instead.
 - **Breaking:** Rename `Web*` handles to `WasmBindgen*`, to make it clearer that these are specific to `wasm-bindgen`.
+- **Breaking:** Rename `DisplayHandle` helpers `appkit` and `uikit` to `app_kit` and `ui_kit` respectively for consistency.
 * Improve documentation on AppKit and UIKit handles.
 
 ## 0.6.2 (2024-05-17)

--- a/src/appkit.rs
+++ b/src/appkit.rs
@@ -47,10 +47,10 @@ impl DisplayHandle<'static> {
     /// ```
     /// # use raw_window_handle::{DisplayHandle, HasDisplayHandle};
     /// # fn do_something(rwh: impl HasDisplayHandle) { let _ = rwh; }
-    /// let handle = DisplayHandle::appkit();
+    /// let handle = DisplayHandle::app_kit();
     /// do_something(handle);
     /// ```
-    pub fn appkit() -> Self {
+    pub fn app_kit() -> Self {
         // SAFETY: No data is borrowed.
         unsafe { Self::borrow_raw(AppKitDisplayHandle::new().into()) }
     }

--- a/src/uikit.rs
+++ b/src/uikit.rs
@@ -47,10 +47,10 @@ impl DisplayHandle<'static> {
     /// ```
     /// # use raw_window_handle::{DisplayHandle, HasDisplayHandle};
     /// # fn do_something(rwh: impl HasDisplayHandle) { let _ = rwh; }
-    /// let handle = DisplayHandle::uikit();
+    /// let handle = DisplayHandle::ui_kit();
     /// do_something(handle);
     /// ```
-    pub fn uikit() -> Self {
+    pub fn ui_kit() -> Self {
         // SAFETY: No data is borrowed.
         unsafe { Self::borrow_raw(UiKitDisplayHandle::new().into()) }
     }


### PR DESCRIPTION
In https://github.com/rust-windowing/raw-window-handle/pull/70#issuecomment-855261670, we decided upon a naming scheme for our types, with the main motivation being "consistency" and "`AndroidNDKHandle` looks weird"[^1].

[^1]: This argument is weakened after https://github.com/rust-windowing/raw-window-handle/pull/214 where this type no longer exists. Now it's only `RawWindowHandle::AndroidNdk` vs. `RawWindowHandle::AndroidNDK`.

I'm still mostly convinced that this is still the right direction to go in because it matches things like `std::net::Ipv4Addr` (if it was `IPv4Addr`, then we should've done something different).

We should apply this naming scheme to methods as well, in particular `DisplayHandle::appkit` and `DisplayHandle::uikit` need an extra `_` to follow normal case-conversion rules.