### PR TITLE
Implement `core::error::Error` when `std` feature is disabled

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,7 +37,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        rust_version: ["1.64", stable, nightly]
+        rust_version: ["1.85", stable, nightly]
 
     steps:
       - uses: actions/checkout@v2
@@ -61,7 +61,7 @@ jobs:
 
       - name: Run tests inside of Chrome
         run: wasm-pack test --chrome --headless
-        if: matrix.rust_version != '1.64'
+        if: matrix.rust_version != '1.85'
 
   apple:
     name: Apple

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,14 +2,14 @@
 name = "raw-window-handle"
 version = "0.6.2"
 authors = ["Osspial <osspial@gmail.com>"]
-edition = "2021"
+edition = "2024"
 description = "Interoperability library for Rust Windowing applications."
 license = "MIT OR Apache-2.0 OR Zlib"
 repository = "https://github.com/rust-windowing/raw-window-handle"
 keywords = ["windowing"]
 readme = "README.md"
 documentation = "https://docs.rs/raw-window-handle"
-rust-version = "1.64"
+rust-version = "1.85"
 
 [features]
 default = ["std"]

--- a/README.md
+++ b/README.md
@@ -18,5 +18,5 @@ be changed without a patch bump to the version of `raw-window-handle`. After
 version `1.0.0` is released, changes to the MSRV will necessitate a minor
 version bump.
 
-When the `wasm-bindgen-0-2` feature is enabled, the MSRV of this crate will be
-raised to the MSRV of the latest version of `wasm-bindgen`.
+When the `std` feature is **disabled** (it is enabled by default), the MSRV will
+be bumped to v1.81 (to support `core::error::Error`).

--- a/README.md
+++ b/README.md
@@ -13,10 +13,7 @@ can use to easily talk with graphics libraries (e.g. gfx-hal).
 ## MSRV Policy
 
 The Minimum Safe Rust Version (MSRV) of this crate as of the time of writing is
-**1.64.0**. For pre-`1.0` releases of `raw-window-handle`, this version will not
+**1.85.0**. For pre-`1.0` releases of `raw-window-handle`, this version will not
 be changed without a patch bump to the version of `raw-window-handle`. After
 version `1.0.0` is released, changes to the MSRV will necessitate a minor
 version bump.
-
-When the `std` feature is **disabled** (it is enabled by default), the MSRV will
-be bumped to v1.81 (to support `core::error::Error`).

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -75,7 +75,11 @@ pub use web::{
 pub use windows::{Win32WindowHandle, WinRtWindowHandle, WindowsDisplayHandle};
 pub use x11::{XcbDisplayHandle, XcbWindowHandle, XlibDisplayHandle, XlibWindowHandle};
 
+#[cfg(not(feature = "std"))]
+use core::error::Error;
 use core::fmt;
+#[cfg(feature = "std")]
+use std::error::Error; // For MSRV.
 
 /// A window handle for a particular windowing system.
 ///
@@ -355,8 +359,7 @@ impl fmt::Display for HandleError {
     }
 }
 
-#[cfg(feature = "std")]
-impl std::error::Error for HandleError {}
+impl Error for HandleError {}
 
 macro_rules! from_impl {
     ($($to:ident, $enum:ident, $from:ty)*) => ($(

--- a/tests/web_handles.rs
+++ b/tests/web_handles.rs
@@ -4,8 +4,8 @@
 
 use core::mem::ManuallyDrop;
 use raw_window_handle::{WasmBindgenCanvasWindowHandle, WasmBindgenOffscreenCanvasWindowHandle};
-use wasm_bindgen::convert::{IntoWasmAbi, RefFromWasmAbi};
 use wasm_bindgen::JsCast;
+use wasm_bindgen::convert::{IntoWasmAbi, RefFromWasmAbi};
 use web_sys::{HtmlCanvasElement, OffscreenCanvas};
 
 #[wasm_bindgen_test::wasm_bindgen_test]


### PR DESCRIPTION
This requires a bit higher MSRV, which we document.

See discussion in https://github.com/rust-windowing/keyboard-types/pull/75 and https://github.com/rust-windowing/keyboard-types/pull/70 for reasoning (basically: MSRV shouldn't hold the nice API back for `no_std` people, and the overlap between `no_std` + low MSRV + windowing is really low).